### PR TITLE
Add templatable script tag

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -426,3 +426,7 @@ api_rev = v3
 [admin]
 # UI to hide sensitive variable fields when set to True
 hide_sensitive_variable_fields = True
+
+[analytics]
+# The location of the tracking snippet to add
+tracking_snippet = 

--- a/airflow/www/app.py
+++ b/airflow/www/app.py
@@ -37,6 +37,9 @@ def create_app(config=None, testing=False):
     app.secret_key = configuration.get('webserver', 'SECRET_KEY')
     app.config['LOGIN_DISABLED'] = not configuration.getboolean('webserver', 'AUTHENTICATE')
 
+    tracking_snippet = configuration.get('analytics', 'TRACKING_SNIPPET')
+    app.add_template_global(name='tracking_snippet', f=tracking_snippet)
+
     csrf.init_app(app)
 
     app.config['TESTING'] = testing

--- a/airflow/www/templates/admin/master.html
+++ b/airflow/www/templates/admin/master.html
@@ -23,6 +23,13 @@
   <link rel="stylesheet" type="text/css" href="{{ url_for("static", filename="main.css") }}">
 {% endblock %}
 
+{% block head %}
+  {{ super() }}
+  {% if tracking_snippet != "" %}
+    <script src="{{ tracking_snippet }}"></script>
+  {% endif %}
+{% endblock %}
+
 {% block tail_js %}
 {{ super() }}
 <script src="{{ url_for('static', filename='jqClock.min.js') }}" type="text/javascript"></script>


### PR DESCRIPTION
Adds ability to inject js tracking to `head` of each page. 

Tracking script to be hosted by cdn with location referenced as `tracking_snippet` in config.