### PR TITLE
[AIRFLOW-5448] Handle istio-proxy for Kubernetes Executor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,4 @@ dmypy.json
 /.bash_history
 /.inputrc
 log.txt*
+osx

--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -218,7 +218,7 @@ class PodLauncher(LoggingMixin):
                 _, tag = container.image.split(":")
                 if semantic_version(tag) < semantic_version("1.3.0-rc.0"):
                     raise AirflowException(
-                        'Please use istio version 1.3.0+ for KubeExecutor compatibility.' +\
+                        'Please use istio version 1.3.0+ for KubernetesExecutor compatibility.' +\
                         ' Detected version {}'.format(tag))
             #  exec into the container
             resp = kubernetes_stream(self._client.connect_get_namespaced_pod_exec,

--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -34,14 +34,17 @@ from requests.exceptions import BaseHTTPError
 from .kube_client import get_kube_client
 from packaging.version import parse as semantic_version
 
+
 class PodStatus:
     PENDING = 'pending'
     RUNNING = 'running'
     FAILED = 'failed'
     SUCCEEDED = 'succeeded'
 
+
 class SidecarNames:
     ISTIO_PROXY = 'istio-proxy'
+
 
 class SleepConfig:
     # Only polls during the start of a pod
@@ -53,6 +56,7 @@ class SleepConfig:
     # to detect when the task is done. The difference
     # between this and POD_RUNNING_POLL is sidecars.
     BASE_CONTAINER_RUNNING_POLL = 2
+
 
 class PodLauncher(LoggingMixin):
     def __init__(self, kube_client=None, in_cluster=True, cluster_context=None,
@@ -215,7 +219,7 @@ class PodLauncher(LoggingMixin):
                 _, tag = container.image.split(":")
                 if semantic_version(tag) < semantic_version("1.3.0-rc.0"):
                     raise AirflowException(
-                        'Please use istio version 1.3.0+ for KubernetesExecutor compatibility.' +\
+                        'Please use istio version 1.3.0+ for KubernetesExecutor compatibility.' +
                         ' Detected version {}'.format(tag))
 
             # Determine the istio-proxy statusPort, which is where /quitquitquit is implemented.

--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -32,13 +32,7 @@ from kubernetes.stream import stream as kubernetes_stream
 from airflow import AirflowException
 from requests.exceptions import BaseHTTPError
 from .kube_client import get_kube_client
-
-# Used to calculate semantic versioning
-try:
-    from packaging.version import parse as semantic_version
-except ImportError:
-    # Python 2
-    from distutils.version import LooseVersion as semantic_version
+from packaging.version import parse as semantic_version
 
 class PodStatus:
     PENDING = 'pending'

--- a/airflow/kubernetes/pod_launcher.py
+++ b/airflow/kubernetes/pod_launcher.py
@@ -237,7 +237,7 @@ class PodLauncher(LoggingMixin):
                 container=SidecarNames.ISTIO_PROXY,
                 command=['curl',
                          '-XPOST',
-                         f'http://127.0.0.1:{status_port}/quitquitquit'])
+                         'http://127.0.0.1:{}/quitquitquit'.format(status_port)])
 
             return True
         return False

--- a/tests/kubernetes/test_pod_launcher.py
+++ b/tests/kubernetes/test_pod_launcher.py
@@ -22,7 +22,7 @@ from airflow.kubernetes.pod_launcher import PodLauncher
 
 import unittest
 import mock
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 
 class TestPodLauncher(unittest.TestCase):

--- a/tests/kubernetes/test_pod_launcher.py
+++ b/tests/kubernetes/test_pod_launcher.py
@@ -119,7 +119,7 @@ class TestPodLauncher(unittest.TestCase):
     def _handle_istio_proxy_with_sidecar_args(self, args):
         sidecar = MagicMock()
         sidecar.name = "istio-proxy"
-        sidecar.image = f"istio/proxyv2:1.3.0"
+        sidecar.image = "istio/proxyv2:1.3.0"
         sidecar.args = args
         pod = MagicMock()
         pod.spec.containers = [sidecar]
@@ -177,6 +177,7 @@ class TestPodLauncher(unittest.TestCase):
         self.pod_launcher._handle_istio_proxy(MagicMock())
         self.mock_kube_client.connect_get_namespaced_pod_exec.\
             assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Here is a draft of the change @ashb suggested to get KubeExecutor working with istio. I'm opening the PR now to get feedback early while I continue to figure out how to comply with Airflow PR standards.