### PR TITLE
Fix k8s tests

### DIFF
--- a/airflow/contrib/kubernetes/istio.py
+++ b/airflow/contrib/kubernetes/istio.py
@@ -18,7 +18,11 @@
 from airflow import AirflowException
 from airflow.utils.log.logging_mixin import LoggingMixin
 from kubernetes.stream import stream
-from packaging.version import parse as semantic_version
+try:
+    from packaging.version import parse as semantic_version
+except ImportError:
+    # Python 2
+    from distutils.version import LooseVersion as semantic_version
 
 
 class SidecarNames:


### PR DESCRIPTION
All our k8s tests on v1-10-5 and v1-10-6 are failing

```
Traceback (most recent call last):
  File "/usr/local/bin/airflow", line 32, in <module>
    args.func(args)
  File "/usr/local/lib/python2.7/dist-packages/airflow/bin/cli.py", line 1102, in initdb
    db.initdb(settings.RBAC)
  File "/usr/local/lib/python2.7/dist-packages/airflow/utils/db.py", line 106, in initdb
    upgradedb()
  File "/usr/local/lib/python2.7/dist-packages/airflow/utils/db.py", line 377, in upgradedb
    command.upgrade(config, 'heads')
  File "/usr/local/lib/python2.7/dist-packages/alembic/command.py", line 298, in upgrade
    script.run_env()
  File "/usr/local/lib/python2.7/dist-packages/alembic/script/base.py", line 489, in run_env
    util.load_python_file(self.dir, "env.py")
  File "/usr/local/lib/python2.7/dist-packages/alembic/util/pyfiles.py", line 98, in load_python_file
    module = load_module_py(module_id, path)
  File "/usr/local/lib/python2.7/dist-packages/alembic/util/compat.py", line 239, in load_module_py
    mod = imp.load_source(module_id, path, fp)
  File "/usr/local/lib/python2.7/dist-packages/airflow/migrations/env.py", line 92, in <module>
    run_migrations_online()
  File "/usr/local/lib/python2.7/dist-packages/airflow/migrations/env.py", line 86, in run_migrations_online
    context.run_migrations()
  File "<string>", line 8, in run_migrations
  File "/usr/local/lib/python2.7/dist-packages/alembic/runtime/environment.py", line 846, in run_migrations
    self.get_context().run_migrations(**kw)
  File "/usr/local/lib/python2.7/dist-packages/alembic/runtime/migration.py", line 518, in run_migrations
    step.migration_fn(**kw)
  File "/usr/local/lib/python2.7/dist-packages/airflow/migrations/versions/cc1e65623dc7_add_max_tries_column_to_task_instance.py", line 70, in upgrade
    dagbag = DagBag(settings.DAGS_FOLDER)
  File "/usr/local/lib/python2.7/dist-packages/airflow/models/dagbag.py", line 94, in __init__
    executor = get_default_executor()
  File "/usr/local/lib/python2.7/dist-packages/airflow/executors/__init__.py", line 48, in get_default_executor
    DEFAULT_EXECUTOR = _get_executor(executor_name)
  File "/usr/local/lib/python2.7/dist-packages/airflow/executors/__init__.py", line 85, in _get_executor
    from airflow.contrib.executors.kubernetes_executor import KubernetesExecutor
  File "/usr/local/lib/python2.7/dist-packages/airflow/contrib/executors/kubernetes_executor.py", line 33, in <module>
    from airflow.contrib.kubernetes.istio import Istio
  File "/usr/local/lib/python2.7/dist-packages/airflow/contrib/kubernetes/istio.py", line 21, in <module>
    from packaging.version import parse as semantic_version
ImportError: No module named packaging.version
```