### PR TITLE
[AIRFLOW-6175] Fixes bug when tasks get stuck in "scheduled" state

### DIFF
--- a/tests/executors/test_executor.py
+++ b/tests/executors/test_executor.py
@@ -56,9 +56,11 @@ class TestExecutor(BaseExecutor):
                 (cmd, prio, queue, sti) = val
                 # Sort by priority (DESC), then date,task, try
                 return -prio, date, dag_id, task_id, try_number
-            sorted_queue = sorted(self.queued_tasks.items(), key=sort_by)
 
-            for (key, (_, _, _, simple_ti)) in sorted_queue:
+            open_slots = self.parallelism - len(self.running)
+            sorted_queue = sorted(self.queued_tasks.items(), key=sort_by)
+            for index in range(min((open_slots, len(sorted_queue)))):
+                (key, (_, _, _, simple_ti)) = sorted_queue[index]
                 self.queued_tasks.pop(key)
                 state = self.mock_task_results[key]
                 ti = simple_ti.construct_task_instance(session=session, lock_for_update=True)

--- a/tests/jobs/test_backfill_job.py
+++ b/tests/jobs/test_backfill_job.py
@@ -434,7 +434,7 @@ class BackfillJobTest(unittest.TestCase):
             if len(running_task_instances) == default_pool_slots:
                 default_pool_task_slot_count_reached_at_least_once = True
 
-        self.assertEquals(8, num_running_task_instances)
+        self.assertEqual(8, num_running_task_instances)
         self.assertTrue(default_pool_task_slot_count_reached_at_least_once)
 
         times_dag_concurrency_limit_reached_in_debug = self._times_called_with(

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -28,6 +28,7 @@ import logging
 import os
 import shutil
 import unittest
+from datetime import timedelta
 from tempfile import mkdtemp
 
 import psutil
@@ -81,6 +82,21 @@ class SchedulerJobTest(unittest.TestCase):
         # Speed up some tests by not running the tasks, just look at what we
         # enqueue!
         self.null_exec = TestExecutor()
+
+    def create_test_dag(self, start_date=DEFAULT_DATE, end_date=DEFAULT_DATE + timedelta(hours=1), **kwargs):
+        dag = DAG(
+            dag_id='test_scheduler_reschedule',
+            start_date=start_date,
+            # Make sure it only creates a single DAG Run
+            end_date=end_date)
+        dag.clear()
+        dag.is_subdag = False
+        with create_session() as session:
+            orm_dag = DagModel(dag_id=dag.dag_id)
+            orm_dag.is_paused = False
+            session.merge(orm_dag)
+            session.commit()
+        return dag
 
     @classmethod
     def setUpClass(cls):
@@ -1802,14 +1818,15 @@ class SchedulerJobTest(unittest.TestCase):
         """
         executor = TestExecutor(do_update=False)
 
-        dagbag = DagBag(executor=executor)
+        dagbag = DagBag(executor=executor, dag_folder=os.path.join(settings.DAGS_FOLDER,
+                                                                   "no_dags.py"))
         dagbag.dags.clear()
         dagbag.executor = executor
 
         dag = DAG(
             dag_id='test_scheduler_reschedule',
             start_date=DEFAULT_DATE)
-        DummyOperator(
+        dummy_task = DummyOperator(
             task_id='dummy',
             dag=dag,
             owner='airflow')
@@ -1817,11 +1834,10 @@ class SchedulerJobTest(unittest.TestCase):
         dag.clear()
         dag.is_subdag = False
 
-        session = settings.Session()
-        orm_dag = DagModel(dag_id=dag.dag_id)
-        orm_dag.is_paused = False
-        session.merge(orm_dag)
-        session.commit()
+        with create_session() as session:
+            orm_dag = DagModel(dag_id=dag.dag_id)
+            orm_dag.is_paused = False
+            session.merge(orm_dag)
 
         dagbag.bag_dag(dag=dag, root_dag=dag, parent_dag=dag)
 
@@ -1839,11 +1855,17 @@ class SchedulerJobTest(unittest.TestCase):
             scheduler.run()
 
         do_schedule()
-        self.assertEqual(1, len(executor.queued_tasks))
-        executor.queued_tasks.clear()
+        with create_session() as session:
+            ti = session.query(TI).filter(TI.dag_id == dag.dag_id,
+                                          TI.task_id == dummy_task.task_id).first()
+        self.assertEqual(0, len(executor.queued_tasks))
+        self.assertEqual(State.SCHEDULED, ti.state)
 
+        executor.do_update = True
         do_schedule()
-        self.assertEqual(2, len(executor.queued_tasks))
+        self.assertEqual(0, len(executor.queued_tasks))
+        ti.refresh_from_db()
+        self.assertEqual(State.SUCCESS, ti.state)
 
     def test_scheduler_sla_miss_callback(self):
         """
@@ -1914,6 +1936,55 @@ class SchedulerJobTest(unittest.TestCase):
         scheduler.manage_slas(dag=dag, session=session)
 
         sla_callback.assert_not_called()
+
+    def test_scheduler_executor_overflow(self):
+        """
+        Test that tasks that are set back to scheduled and removed from the executor
+        queue in the case of an overflow.
+        """
+        executor = TestExecutor(do_update=True, parallelism=3)
+
+        with create_session() as session:
+            dagbag = DagBag(executor=executor, dag_folder=os.path.join(settings.DAGS_FOLDER,
+                                                                       "no_dags.py"))
+            dag = self.create_test_dag()
+            dagbag.bag_dag(dag=dag, root_dag=dag, parent_dag=dag)
+            dag = self.create_test_dag()
+            task = DummyOperator(
+                task_id='dummy',
+                dag=dag,
+                owner='airflow')
+            tis = []
+            for i in range(1, 10):
+                ti = TI(task, DEFAULT_DATE + timedelta(days=i))
+                ti.state = State.SCHEDULED
+                tis.append(ti)
+                session.merge(ti)
+
+            # scheduler._process_dags(simple_dag_bag)
+            @mock.patch('airflow.models.DagBag', return_value=dagbag)
+            @mock.patch('airflow.models.DagBag.collect_dags')
+            @mock.patch('airflow.jobs.scheduler_job.SchedulerJob._change_state_for_tis_without_dagrun')
+            def do_schedule(mock_dagbag, mock_collect_dags, mock_change_state_for_tis_without_dagrun):
+                # Use a empty file since the above mock will return the
+                # expected DAGs. Also specify only a single file so that it doesn't
+                # try to schedule the above DAG repeatedly.
+                scheduler = SchedulerJob(num_runs=1,
+                                         executor=executor,
+                                         subdir=os.path.join(settings.DAGS_FOLDER,
+                                                             "no_dags.py"))
+                scheduler.heartrate = 0
+                scheduler.run()
+
+            do_schedule()
+            for ti in tis:
+                ti.refresh_from_db()
+            self.assertEqual(len(executor.queued_tasks), 0)
+
+            successful_tasks = [ti for ti in tis if ti.state == State.SUCCESS]
+            scheduled_tasks = [ti for ti in tis if ti.state == State.SCHEDULED]
+            self.assertEqual(3, len(successful_tasks))
+            self.assertEqual(6, len(scheduled_tasks))
 
     def test_scheduler_sla_miss_callback_sent_notification(self):
         """
@@ -2060,11 +2131,10 @@ class SchedulerJobTest(unittest.TestCase):
         dag.clear()
         dag.is_subdag = False
 
-        session = settings.Session()
-        orm_dag = DagModel(dag_id=dag.dag_id)
-        orm_dag.is_paused = False
-        session.merge(orm_dag)
-        session.commit()
+        with create_session() as session:
+            orm_dag = DagModel(dag_id=dag.dag_id)
+            orm_dag.is_paused = False
+            session.merge(orm_dag)
 
         dagbag.bag_dag(dag=dag, root_dag=dag, parent_dag=dag)
 
@@ -2082,7 +2152,14 @@ class SchedulerJobTest(unittest.TestCase):
             scheduler.run()
 
         do_schedule()
-        self.assertEqual(1, len(executor.queued_tasks))
+        with create_session() as session:
+            ti = session.query(TI).filter(TI.dag_id == 'test_retry_still_in_executor',
+                                          TI.task_id == 'test_retry_handling_op').first()
+        ti.task = dag_task1
+
+        # Nothing should be left in the queued_tasks as we don't do update in MockExecutor yet,
+        # and the queued_tasks will be cleared by scheduler job.
+        self.assertEqual(0, len(executor.queued_tasks))
 
         def run_with_error(task, ignore_ti_state=False):
             try:
@@ -2105,33 +2182,23 @@ class SchedulerJobTest(unittest.TestCase):
         self.assertEqual(ti.state, State.UP_FOR_RETRY)
         self.assertEqual(ti.try_number, 2)
 
-        ti.refresh_from_db(lock_for_update=True, session=session)
-        ti.state = State.SCHEDULED
-        session.merge(ti)
-        session.commit()
+        with create_session() as session:
+            ti.refresh_from_db(lock_for_update=True, session=session)
+            ti.state = State.SCHEDULED
+            session.merge(ti)
 
-        # do not schedule
+        # do schedule
         do_schedule()
-        self.assertTrue(executor.has_task(ti))
-        ti.refresh_from_db()
-        # removing self.assertEqual(ti.state, State.SCHEDULED)
-        # as scheduler will move state from SCHEDULED to QUEUED
-
-        # now the executor has cleared and it should be allowed the re-queue,
-        # but tasks stay in the executor.queued_tasks after executor.heartbeat()
-        # will be set back to SCHEDULED state
-        executor.queued_tasks.clear()
-        do_schedule()
-        ti.refresh_from_db()
-
+        # MockExecutor is not aware of the TI since we don't do update yet
+        # and no trace of this TI will be left in the executor.
+        self.assertFalse(executor.has_task(ti))
         self.assertEqual(ti.state, State.SCHEDULED)
 
         # To verify that task does get re-queued.
-        executor.queued_tasks.clear()
         executor.do_update = True
         do_schedule()
         ti.refresh_from_db()
-        self.assertIn(ti.state, [State.RUNNING, State.SUCCESS])
+        self.assertEqual(ti.state, State.SUCCESS)
 
     @unittest.skipUnless("INTEGRATION" in os.environ, "Can only run end to end")
     def test_retry_handling_job(self):

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -2167,11 +2167,6 @@ class SchedulerJobTest(unittest.TestCase):
             except AirflowException:
                 pass
 
-        ti_tuple = six.next(six.itervalues(executor.queued_tasks))
-        (command, priority, queue, simple_ti) = ti_tuple
-        ti = simple_ti.construct_task_instance()
-        ti.task = dag_task1
-
         self.assertEqual(ti.try_number, 1)
         # At this point, scheduler has tried to schedule the task once and
         # heartbeated the executor once, which moved the state of the task from


### PR DESCRIPTION
…6732)

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-6175

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
There is a bug caused by scheduler_jobs refactor which leads to task failure and scheduler locking.

Essentially when a there is an overflow of tasks going into the scheduler, the tasks are set back to scheduled, but are not removed from the executor's queued_tasks queue.

This means that the executor will attempt to run tasks that are in the scheduled state, but those tasks will fail dependency checks. Eventually the queue is filled with scheduled tasks, and the scheduler can no longer run.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain docstrings that explain what it does
  - If you implement backwards incompatible changes, please leave a note in the [Updating.md](https://github.com/apache/airflow/blob/master/UPDATING.md) so we can assign it to a appropriate release
