### PR TITLE
[AIRFLOW-6504] K8sExec: Allow specifying configmap for Airflow Local Setting

### DIFF
--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -683,6 +683,9 @@ namespace = default
 # The name of the Kubernetes ConfigMap Containing the Airflow Configuration (this file)
 airflow_configmap =
 
+# The name of the Kubernetes ConfigMap Containing the airflow_local_settings.py file
+airflow_local_settings_configmap =
+
 # For docker image already contains DAGs, this is set to `True`, and the worker will search for dags in dags_folder,
 # otherwise use git sync or dags volume claim to mount DAGs
 dags_in_image = False

--- a/airflow/contrib/executors/kubernetes_executor.py
+++ b/airflow/contrib/executors/kubernetes_executor.py
@@ -254,6 +254,11 @@ class KubeConfig:
         # configmap
         self.airflow_configmap = conf.get(self.kubernetes_section, 'airflow_configmap')
 
+        # The worker pod may optionally have a valid Airflow local settings loaded via a
+        # configmap
+        self.airflow_local_settings_configmap = conf.get(
+            self.kubernetes_section, 'airflow_local_settings_configmap')
+
         affinity_json = conf.get(self.kubernetes_section, 'affinity')
         if affinity_json:
             self.kube_affinity = json.loads(affinity_json)

--- a/airflow/contrib/kubernetes/worker_configuration.py
+++ b/airflow/contrib/kubernetes/worker_configuration.py
@@ -328,6 +328,22 @@ class WorkerConfiguration(LoggingMixin):
                 'readOnly': True
             }
 
+        if self.kube_config.airflow_local_settings_configmap:
+            config_volume_name = 'airflow-config'
+            config_path = '{}/config/airflow_local_settings.py'.format(self.worker_airflow_home)
+            volumes[config_volume_name] = {
+                'name': config_volume_name,
+                'configMap': {
+                    'name': self.kube_config.airflow_local_settings_configmap
+                }
+            }
+            volume_mounts[config_volume_name] = {
+                'name': config_volume_name,
+                'mountPath': config_path,
+                'subPath': 'airflow_local_settings.py',
+                'readOnly': True
+            }
+
         return volumes, volume_mounts
 
     def generate_dag_volume_mount_path(self):


### PR DESCRIPTION
Currently `airflow.cfg` file can be passed via ConfigMap using `airflow_configmap` under `[kubernetes]` section setting.

We want to be able to specify `airflow_local_settings.py` via configmap too so that the Kubernetes Worker has this file. We need `airflow_local_settings.py` to specify pod_mutation_hook. 

Without that currently, if we are using `KubernetesExecutor` and have a task with `KubernetesPodOperator`, it will inherit and change Pod using `pod_mutation_hook`

**Astronomer specific use-case**: We need this to move pods launched via K8sExec and K8sPodOperator to dynamic-node-pool

---
Issue link: https://issues.apache.org/jira/browse/AIRFLOW-6504

- [x] Description above provides context of the change
- [x] Commit message/PR title starts with `[AIRFLOW-NNNN]`. AIRFLOW-NNNN = JIRA ID<sup>*</sup>
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

<sup>*</sup> For document-only changes commit message can start with `[AIRFLOW-XXXX]`.

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
