### PR TITLE
Adds option to delete k8sexecutor workers only on success

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -1750,7 +1750,14 @@
       default: "IfNotPresent"
     - name: delete_worker_pods
       description: |
-        If True (default), worker pods will be deleted upon termination
+        If True, all worker pods will be deleted upon termination
+      version_added: ~
+      type: string
+      example: ~
+      default: "True"
+    - name: delete_worker_pods_on_success
+      description: |
+        If True (default), worker pods will be deleted only on task success
       version_added: ~
       type: string
       example: ~

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -804,8 +804,11 @@ worker_container_repository =
 worker_container_tag =
 worker_container_image_pull_policy = IfNotPresent
 
-# If True (default), worker pods will be deleted upon termination
+# If True, all worker pods will be deleted upon termination
 delete_worker_pods = True
+
+# If True (default), worker pods will be deleted only on task success
+delete_worker_pods_on_success = True
 
 # Number of Kubernetes Worker Pod creation calls per scheduler loop
 worker_pods_creation_batch_size = 1

--- a/tests/contrib/executors/test_kubernetes_executor.py
+++ b/tests/contrib/executors/test_kubernetes_executor.py
@@ -1041,47 +1041,67 @@ class TestKubernetesExecutor(unittest.TestCase):
         executor._change_state(key, State.RUNNING, 'pod_id', 'default')
         self.assertTrue(executor.event_buffer[key] == State.RUNNING)
 
-    @mock.patch('airflow.contrib.executors.kubernetes_executor.KubeConfig')
     @mock.patch('airflow.contrib.executors.kubernetes_executor.KubernetesJobWatcher')
     @mock.patch('airflow.contrib.executors.kubernetes_executor.get_kube_client')
     @mock.patch('airflow.contrib.executors.kubernetes_executor.AirflowKubernetesScheduler.delete_pod')
-    def test_change_state_success(self, mock_delete_pod, mock_get_kube_client, mock_kubernetes_job_watcher,
-                                  mock_kube_config):
+    def test_change_state_success(self, mock_delete_pod, mock_get_kube_client, mock_kubernetes_job_watcher):
         executor = KubernetesExecutor()
         executor.start()
         test_time = timezone.utcnow()
         key = ('dag_id', 'task_id', test_time, 'try_number2')
         executor._change_state(key, State.SUCCESS, 'pod_id', 'default')
         self.assertTrue(executor.event_buffer[key] == State.SUCCESS)
-        mock_delete_pod.assert_called_with('pod_id', 'default')
+        mock_delete_pod.assert_called_once_with('pod_id', 'default')
 
-    @mock.patch('airflow.contrib.executors.kubernetes_executor.KubeConfig')
     @mock.patch('airflow.contrib.executors.kubernetes_executor.KubernetesJobWatcher')
     @mock.patch('airflow.contrib.executors.kubernetes_executor.get_kube_client')
     @mock.patch('airflow.contrib.executors.kubernetes_executor.AirflowKubernetesScheduler.delete_pod')
-    def test_change_state_failed(self, mock_delete_pod, mock_get_kube_client, mock_kubernetes_job_watcher,
-                                 mock_kube_config):
+    def test_change_state_failed_no_deletion(
+        self,
+        mock_delete_pod,
+        mock_get_kube_client,
+        mock_kubernetes_job_watcher
+    ):
         executor = KubernetesExecutor()
+        executor.kube_config.delete_worker_pods = False
+        executor.kube_config.delete_worker_pods_on_success = True
         executor.start()
-        key = ('dag_id', 'task_id', 'ex_time', 'try_number3')
+        test_time = timezone.utcnow()
+        key = ('dag_id', 'task_id', test_time, 'try_number3')
         executor._change_state(key, State.FAILED, 'pod_id', 'default')
         self.assertTrue(executor.event_buffer[key] == State.FAILED)
-        mock_delete_pod.assert_called_with('pod_id', 'default')
+        mock_delete_pod.assert_not_called()
+# pylint: enable=unused-argument
 
-    @mock.patch('airflow.contrib.executors.kubernetes_executor.KubeConfig')
     @mock.patch('airflow.contrib.executors.kubernetes_executor.KubernetesJobWatcher')
     @mock.patch('airflow.contrib.executors.kubernetes_executor.get_kube_client')
     @mock.patch('airflow.contrib.executors.kubernetes_executor.AirflowKubernetesScheduler.delete_pod')
     def test_change_state_skip_pod_deletion(self, mock_delete_pod, mock_get_kube_client,
-                                            mock_kubernetes_job_watcher, mock_kube_config):
+                                            mock_kubernetes_job_watcher):
         test_time = timezone.utcnow()
         executor = KubernetesExecutor()
         executor.kube_config.delete_worker_pods = False
+        executor.kube_config.delete_worker_pods_on_success = False
+
         executor.start()
         key = ('dag_id', 'task_id', test_time, 'try_number2')
         executor._change_state(key, State.SUCCESS, 'pod_id', 'default')
         self.assertTrue(executor.event_buffer[key] == State.SUCCESS)
         mock_delete_pod.assert_not_called()
+
+    @mock.patch('airflow.contrib.executors.kubernetes_executor.KubernetesJobWatcher')
+    @mock.patch('airflow.contrib.executors.kubernetes_executor.get_kube_client')
+    @mock.patch('airflow.contrib.executors.kubernetes_executor.AirflowKubernetesScheduler.delete_pod')
+    def test_change_state_failed_pod_deletion(self, mock_delete_pod, mock_get_kube_client,
+                                              mock_kubernetes_job_watcher):
+        executor = KubernetesExecutor()
+        executor.kube_config.delete_worker_pods_on_success = True
+
+        executor.start()
+        key = ('dag_id', 'task_id', 'ex_time', 'try_number2')
+        executor._change_state(key, State.FAILED, 'pod_id', 'test-namespace')
+        self.assertTrue(executor.event_buffer[key] == State.FAILED)
+        mock_delete_pod.assert_called_once_with('pod_id', 'test-namespace')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
---

Many users want the ability to investigate failed tasks, but if the pods are deleted then the logs are unreachable. this PR adds a "delete_on_success" option which keeps failed tasks around. 

Make sure to mark the boxes below before creating PR: [x]

- [ ] Description above provides context of the change
- [ ] Unit tests coverage for changes (not needed for documentation changes)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions.
- [ ] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
