### PR TITLE
Bump to v1.10.7+astro.9

### DIFF
--- a/airflow/version.py
+++ b/airflow/version.py
@@ -18,4 +18,4 @@
 # under the License.
 #
 
-version = '1.10.7+astro.8'
+version = '1.10.7+astro.9'


### PR DESCRIPTION
In-line to release ap-airflow 1.10.7-9 docker image