### PR TITLE
Bump to v1.10.7+astro.10 (BackPort Secrets Backend)

### DIFF
--- a/airflow/version.py
+++ b/airflow/version.py
@@ -18,4 +18,4 @@
 # under the License.
 #
 
-version = '1.10.7.dev1+astro.10'
+version = '1.10.7+astro.10'


### PR DESCRIPTION
Changelog between **v1.10.7+astro.9** and **v1.10.7+astro.10**:

Backported all the Secrets Backend commits.

d1c5fdc28 Store info about the latest version in the series (#487)
f47108ff9 Build DEV packages on each commit if it is not a tag
d9d033549 Bump to v1.10.7.dev1+astro.10
d6d666c33 Allow setting Airflow Variable values to empty string ('') (#8021)
6a7130f55 Get Airflow Variables from AWS Systems Manager Parameter Store (#7945)
595ede548 Get Airflow Variables from GCP Secrets Manager (#7946)
59435bb88 Get Airflow Variables from Hashicorp Vault (#7944)
fe1a6a3bd Get Airflow Variables from Environment Variables (#7923)
89052690e [AIRFLOW-6987] Avoid creating default connections (#7629)
1623b80bc Make BaseSecretsBackend.build_path generic (#7948)
fe0a9d850 Fix CloudSecretsManagerBackend invalid connections_prefix (#7861)
008cb6ebe Standardize SecretBackend class names (#7846)
5ddff01e8 [AIRFLOW-7105] Unify Secrets Backend method interfaces (#7830)
19bcf781b [AIRFLOW-7104] Add Secret backend for GCP Secrets Manager (#7795)
cff559cbb [AIRFLOW-5705] Make AwsSsmSecretsBackend consistent with VaultBackend (#7753)
99bb2a7ef [AIRFLOW-7076] Add support for HashiCorp Vault as Secrets Backend (#7741)
afae4b62b [AIRFLOW-5705] Fix bugs in AWS SSM Secrets Backend (#7745)
29015f537 [AIRFLOW-5705] Fix bug in Secrets Backend (#7742)
2a82f5365 [AIRFLOW-5705] Add secrets backend and support for AWS SSM (#6376)

Available for testing at:

```
docker pull astronomerio/ap-airflow:1.10.7-10.dev-buster-onbuild
```