### PR TITLE
Ensure test_logging_config.test_reload_module works in spawn mode.

### DIFF
--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -134,6 +134,7 @@ def settings_context(content, directory=None, name='LOGGING_CONFIG'):
     sys.path.append(settings_root)
 
     with conf_vars({('logging', 'logging_config_class'): module}):
+        os.environ["AIRFLOW__LOGGING__LOGGING_CONFIG_CLASS"] = module
         yield settings_file
 
     sys.path.remove(settings_root)


### PR DESCRIPTION
Currently, the `test_logging_config.test_reload_module` test fails when processes are created in `spawn` mode, because the change in how memory is shared between processes means the test logging configs don't get loaded properly in the child.

This saves the logging config to an environment variable, which is accessible from the child process.

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
