### PR TITLE
Remove py2 tag from published wheel 

### DIFF
--- a/scripts/ci/astronomer-release.sh
+++ b/scripts/ci/astronomer-release.sh
@@ -53,7 +53,7 @@ ls -altr dist/*/*
 python3 astronomer-certified-setup.py bdist_wheel  --dist-dir dist/astronomer-certified dist/apache-airflow/apache_airflow-*.whl
 
 # Get the version of AC (Example 1.10.7.post7)
-CURRENT_AC_VERSION=$(echo dist/astronomer-certified/astronomer_certified-*.whl | sed -E 's|.*astronomer_certified-(.+)-py2.py3-none-any.whl|\1|')
+CURRENT_AC_VERSION=$(echo dist/astronomer-certified/astronomer_certified-*.whl | sed -E 's|.*astronomer_certified-(.+)-py3-none-any.whl|\1|')
 export CURRENT_AC_VERSION
 echo "AC Version: $CURRENT_AC_VERSION"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ license_files =
   NOTICE
 
 [bdist_wheel]
-universal=1
+python-tag=py3
 
 [files]
 packages = airflow

--- a/setup.py
+++ b/setup.py
@@ -408,7 +408,7 @@ devel = [
     'contextdecorator;python_version<"3.4"',
     'coverage',
     'dumb-init>=1.2.2',
-    'flake8>=3.6.0',
+    'flake8>=3.6.0, <3.8.0',
     'flake8-colors',
     'flaky',
     'freezegun',


### PR DESCRIPTION
Remove py2 tag from published wheel & Pin Flake8 (we don't need to fix the Flake8 error in AC patch release)

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
