### PR TITLE
Make loading plugins from entrypoint fault-tolerant - 1.10.* Backport

### DIFF
--- a/airflow/plugins_manager.py
+++ b/airflow/plugins_manager.py
@@ -99,6 +99,7 @@ def load_entrypoint_plugins(entry_points, airflow_plugins):
     :type airflow_plugins: list[type[airflow.plugins_manager.AirflowPlugin]]
     :rtype: list[airflow.plugins_manager.AirflowPlugin]
     """
+    global import_errors  # pylint: disable=global-statement
     for entry_point in entry_points:
         log.debug('Importing entry_point plugin %s', entry_point.name)
         try:
@@ -107,8 +108,9 @@ def load_entrypoint_plugins(entry_points, airflow_plugins):
                 if callable(getattr(plugin_obj, 'on_load', None)):
                     plugin_obj.on_load()
                     airflow_plugins.append(plugin_obj)
-        except Exception:  # pylint: disable=broad-except
+        except Exception as e:  # pylint: disable=broad-except
             log.exception("Failed to import plugin %s", entry_point.name)
+            import_errors[entry_point.module_name] = str(e)
     return airflow_plugins
 
 

--- a/tests/plugins/test_plugins_manager_rbac.py
+++ b/tests/plugins/test_plugins_manager_rbac.py
@@ -23,7 +23,9 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import unittest
+from tests.compat import mock
 
+import pkg_resources
 
 from airflow.www_rbac import app as application
 
@@ -71,3 +73,25 @@ class PluginsTestRBAC(unittest.TestCase):
         # Blueprint should be present in the app
         self.assertTrue('test_plugin' in self.app.blueprints)
         self.assertEqual(self.app.blueprints['test_plugin'].name, bp.name)
+
+    @mock.patch('pkg_resources.iter_entry_points')
+    def test_entrypoint_plugin_errors_dont_raise_exceptions(self, mock_ep_plugins):
+        """
+        Test that Airflow does not raise an Error if there is any Exception because of the
+        Plugin.
+        """
+        from airflow.plugins_manager import load_entrypoint_plugins
+
+        mock_entrypoint = mock.Mock()
+        mock_entrypoint.name = 'test-entrypoint'
+        mock_entrypoint.module_name = 'test.plugins.test_plugins_manager'
+        mock_entrypoint.load.side_effect = Exception('Version Conflict')
+        mock_ep_plugins.return_value = [mock_entrypoint]
+
+        with self.assertLogs("airflow.plugins_manager", level="ERROR") as log_output:
+            load_entrypoint_plugins(pkg_resources.iter_entry_points('airflow.plugins'), [])
+            received_logs = log_output.output[0]
+            # Assert Traceback is shown too
+            assert "Traceback (most recent call last):" in received_logs
+            assert "Version Conflict" in received_logs
+            assert "Failed to import plugin test-entrypoint" in received_logs

--- a/tests/plugins/test_plugins_manager_rbac.py
+++ b/tests/plugins/test_plugins_manager_rbac.py
@@ -80,7 +80,7 @@ class PluginsTestRBAC(unittest.TestCase):
         Test that Airflow does not raise an Error if there is any Exception because of the
         Plugin.
         """
-        from airflow.plugins_manager import load_entrypoint_plugins
+        from airflow.plugins_manager import load_entrypoint_plugins, import_errors
 
         mock_entrypoint = mock.Mock()
         mock_entrypoint.name = 'test-entrypoint'
@@ -95,3 +95,4 @@ class PluginsTestRBAC(unittest.TestCase):
             assert "Traceback (most recent call last):" in received_logs
             assert "Version Conflict" in received_logs
             assert "Failed to import plugin test-entrypoint" in received_logs
+            assert ('test.plugins.test_plugins_manager', 'Version Conflict') in import_errors.items()


### PR DESCRIPTION
Backport of (#8732)

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
