### PR TITLE
Minor bugfixes when DAG Serialization is enabled by default

### DIFF
--- a/airflow/api/common/experimental/trigger_dag.py
+++ b/airflow/api/common/experimental/trigger_dag.py
@@ -21,6 +21,8 @@ import json
 from datetime import datetime
 from typing import Union, Optional, List
 
+import pendulum
+
 from airflow.exceptions import DagRunAlreadyExists, DagNotFound
 from airflow.models import DagRun, DagBag, DagModel
 from airflow.utils import timezone
@@ -54,7 +56,6 @@ def _trigger_dag(
         raise DagNotFound("Dag id {} not found".format(dag_id))
 
     execution_date = execution_date if execution_date else timezone.utcnow()
-
     assert timezone.is_localized(execution_date)
 
     if replace_microseconds:
@@ -62,7 +63,7 @@ def _trigger_dag(
 
     if dag.default_args and 'start_date' in dag.default_args:
         min_dag_start_date = dag.default_args["start_date"]
-        if min_dag_start_date and execution_date < min_dag_start_date:
+        if min_dag_start_date and pendulum.instance(execution_date) < min_dag_start_date:
             raise ValueError(
                 "The execution_date [{0}] should be >= start_date [{1}] from DAG's default_args".format(
                     execution_date.isoformat(),

--- a/tests/models/test_dag.py
+++ b/tests/models/test_dag.py
@@ -805,11 +805,12 @@ class DagTest(unittest.TestCase):
             dag_id,
             is_paused_upon_creation=True,
         )
-        dag.fileloc = dag_fileloc
         session = settings.Session()
         dag.sync_to_db(session=session)
 
         orm_dag = session.query(DagModel).filter(DagModel.dag_id == dag_id).one()
+        orm_dag.fileloc = dag_fileloc
+        session.merge(orm_dag)
 
         self.assertTrue(orm_dag.is_active)
         self.assertEqual(orm_dag.fileloc, dag_fileloc)

--- a/tests/www_rbac/test_views.py
+++ b/tests/www_rbac/test_views.py
@@ -656,6 +656,7 @@ class TestAirflowBaseViews(TestBase):
         self.check_content_not_in_response('Failed to load file', resp)
         self.check_content_in_response('example_bash_operator', resp)
 
+    @unittest.skipIf(settings.STORE_SERIALIZED_DAGS, reason="DAG Serialization is enabled")
     def test_code_no_file(self):
         url = 'code?dag_id=example_bash_operator'
         mock_open_patch = mock.mock_open(read_data='')


### PR DESCRIPTION
There is 1 code change where we convert datetime object to Pendulum because of following error:

```
        if dag.default_args and 'start_date' in dag.default_args:
            min_dag_start_date = pendulum.instance(dag.default_args["start_date"])
            print("min_dag_start_date", min_dag_start_date)
            print("min_dag_start_date", type(min_dag_start_date))
>           if min_dag_start_date and execution_date < min_dag_start_date:
E           TypeError: can't compare offset-naive and offset-aware datetimes
```

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
