### PR TITLE
Stop restarting gunicorn workers

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -698,7 +698,7 @@
       version_added: ~
       type: string
       example: ~
-      default: "30"
+      default: "86400"
     - name: secret_key
       description: |
         Secret key used to run your flask app

--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -698,7 +698,7 @@
       version_added: ~
       type: string
       example: ~
-      default: "86400"
+      default: "0"
     - name: secret_key
       description: |
         Secret key used to run your flask app

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -338,7 +338,7 @@ web_server_worker_timeout = 120
 worker_refresh_batch_size = 1
 
 # Number of seconds to wait before refreshing a batch of workers.
-worker_refresh_interval = 86400
+worker_refresh_interval = 0
 
 # Secret key used to run your flask app
 # It should be as random as possible

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -338,7 +338,7 @@ web_server_worker_timeout = 120
 worker_refresh_batch_size = 1
 
 # Number of seconds to wait before refreshing a batch of workers.
-worker_refresh_interval = 30
+worker_refresh_interval = 86400
 
 # Secret key used to run your flask app
 # It should be as random as possible


### PR DESCRIPTION
We don't need to restart gunicorn workers when Dag Serialization is enabled

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
