### PR TITLE
Fix default configs for tests

### DIFF
--- a/airflow/config_templates/default_test.cfg
+++ b/airflow/config_templates/default_test.cfg
@@ -53,6 +53,9 @@ secure_mode = False
 hostname_callable = socket:getfqdn
 worker_precheck = False
 default_task_retries = 0
+store_serialized_dags = False
+store_dag_code = False
+worker_refresh_interval=30
 
 [cli]
 api_client = airflow.api.client.local_client


### PR DESCRIPTION
The tests are currently hanging after we changed the defaults https://travis-ci.com/github/astronomer/airflow/builds/174264082

For now this is a good enough workaround. From AC 1.10.11 we can fix the issue

---
Make sure to mark the boxes below before creating PR: [x]

- [x] Description above provides context of the change
- [x] Unit tests coverage for changes (not needed for documentation changes)
- [x] Target Github ISSUE in description if exists
- [x] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [x] Relevant documentation is updated including usage instructions.
- [x] I will engage committers as explained in [Contribution Workflow Example](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#contribution-workflow-example).

---
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
Read the [Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines) for more information.
