### PR TITLE
Change default auth for experimental API to role_based_auth

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -555,7 +555,7 @@
       version_added: ~
       type: string
       example: ~
-      default: "airflow.api.auth.backend.deny_all"
+      default: "airflow.api.auth.backend.role_based_auth"
 - name: lineage
   description: ~
   options:

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -291,7 +291,7 @@ fail_fast = False
 # How to authenticate users of the API. See
 # https://airflow.apache.org/docs/stable/security.html for possible values.
 # ("airflow.api.auth.backend.default" allows all requests for historic reasons)
-auth_backend = airflow.api.auth.backend.deny_all
+auth_backend = airflow.api.auth.backend.role_based_auth
 
 [lineage]
 # what lineage backend to use


### PR DESCRIPTION
It would have the same default of "deny_all", as without our auth/JWT layer in front, it wouldn't ever find a valid user (unless made via a logged in browser session etc.)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
