### PR TITLE
Move callbacks from Scheduler loop to DagProcessorProcess

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1504,7 +1504,7 @@ class SchedulerJob(BaseJob):  # pylint: disable=too-many-instance-attributes
             # Work out if we should allow creating a new DagRun now?
             self._update_dag_next_dagrun(session.query(DagModel).get(dag_run.dag_id), dag, session)
 
-            dag_run._callback = DagCallbackRequest(  # pylint: disable=protected-access
+            dag_run.callback = DagCallbackRequest(
                 full_filepath=dag.fileloc,
                 dag_id=dag.dag_id,
                 execution_date=dag_run.execution_date,

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -101,12 +101,12 @@ class DagRun(Base, LoggingMixin):
         self.conf = conf or {}
         self.state = state
         self.run_type = run_type
-        self._callback: Optional[callback_requests.CallbackRequest] = None
+        self._callback: Optional[callback_requests.DagCallbackRequest] = None
         super().__init__()
 
     @orm.reconstructor
     def init_on_load(self):
-        self._callback: Optional[callback_requests.CallbackRequest] = None
+        self._callback: Optional[callback_requests.DagCallbackRequest] = None
 
     def __repr__(self):
         return (
@@ -442,12 +442,12 @@ class DagRun(Base, LoggingMixin):
                 dag.handle_callback(self, success=False, reason='all_tasks_deadlocked', session=session)
             else:
                 self._callback = callback_requests.DagCallbackRequest(
-                        full_filepath=dag.fileloc,
-                        dag_id=self.dag_id,
-                        execution_date=self.execution_date,
-                        is_failure_callback=True,
-                        msg='all_tasks_deadlocked'
-                    )
+                    full_filepath=dag.fileloc,
+                    dag_id=self.dag_id,
+                    execution_date=self.execution_date,
+                    is_failure_callback=True,
+                    msg='all_tasks_deadlocked'
+                )
 
         # finally, if the roots aren't done, the dag is still running
         else:
@@ -629,5 +629,5 @@ class DagRun(Base, LoggingMixin):
         return dagruns
 
     @property
-    def callback(self) -> Optional[callback_requests.CallbackRequest]:
+    def callback(self) -> Optional[callback_requests.DagCallbackRequest]:
         return self._callback

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -354,14 +354,15 @@ class DagRun(Base, LoggingMixin):
         ).first()
 
     @provide_session
-    def update_state(self, session: Session = None, handle_callback: Optional[bool] = True) -> List[TI]:
+    def update_state(self, session: Session = None, handle_callback: bool = True) -> List[TI]:
         """
         Determines the overall state of the DagRun based on the state
         of its TaskInstances.
 
         :param session: Sqlalchemy ORM Session
         :type session: Session
-        :param handle_callback: To run Dag Callbacks or not
+        :param handle_callback: Should dag callbacks (success/failure, SLA etc) be invoked
+            directly (default: true) or recorded as a pending request in the ``callback`` property
         :type handle_callback: bool
         :return: ready_tis: the tis that can be scheduled in the current loop
         :rtype ready_tis: list[airflow.models.TaskInstance]

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -19,7 +19,7 @@ from datetime import datetime
 from typing import Any, List, Optional, Tuple, Union
 
 from sqlalchemy import (
-    Boolean, Column, DateTime, Index, Integer, PickleType, String, UniqueConstraint, and_, func, or_,
+    Boolean, Column, DateTime, Index, Integer, PickleType, String, UniqueConstraint, and_, func, or_, orm,
 )
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.declarative import declared_attr
@@ -35,7 +35,7 @@ from airflow.settings import task_instance_mutation_hook
 from airflow.stats import Stats
 from airflow.ti_deps.dep_context import DepContext
 from airflow.ti_deps.dependencies_states import SCHEDULEABLE_STATES
-from airflow.utils import timezone
+from airflow.utils import callback_requests, timezone
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import provide_session
 from airflow.utils.sqlalchemy import UtcDateTime, skip_locked
@@ -101,7 +101,12 @@ class DagRun(Base, LoggingMixin):
         self.conf = conf or {}
         self.state = state
         self.run_type = run_type
+        self._callback: Optional[callback_requests.CallbackRequest] = None
         super().__init__()
+
+    @orm.reconstructor
+    def init_on_load(self):
+        self._callback: Optional[callback_requests.CallbackRequest] = None
 
     def __repr__(self):
         return (
@@ -349,13 +354,15 @@ class DagRun(Base, LoggingMixin):
         ).first()
 
     @provide_session
-    def update_state(self, session: Session = None) -> List[TI]:
+    def update_state(self, session: Session = None, handle_callback: Optional[bool] = True) -> List[TI]:
         """
         Determines the overall state of the DagRun based on the state
         of its TaskInstances.
 
         :param session: Sqlalchemy ORM Session
         :type session: Session
+        :param handle_callback: To run Dag Callbacks or not
+        :type handle_callback: bool
         :return: ready_tis: the tis that can be scheduled in the current loop
         :rtype ready_tis: list[airflow.models.TaskInstance]
         """
@@ -373,8 +380,7 @@ class DagRun(Base, LoggingMixin):
         unfinished_tasks = [t for t in tis if t.state in State.unfinished()]
         finished_tasks = [t for t in tis if t.state in State.finished() + [State.UPSTREAM_FAILED]]
         none_depends_on_past = all(not t.task.depends_on_past for t in unfinished_tasks)
-        none_task_concurrency = all(t.task.task_concurrency is None
-                                    for t in unfinished_tasks)
+        none_task_concurrency = all(t.task.task_concurrency is None for t in unfinished_tasks)
         if unfinished_tasks:
             scheduleable_tasks = [ut for ut in unfinished_tasks if ut.state in SCHEDULEABLE_STATES]
             self.log.debug(
@@ -393,16 +399,22 @@ class DagRun(Base, LoggingMixin):
         leaf_task_ids = {t.task_id for t in dag.leaves}
         leaf_tis = [ti for ti in tis if ti.task_id in leaf_task_ids]
 
-        # TODO[ha]: These callbacks shouldn't run in the scheduler loop - check if Kamil changed this to run
-        # via the dag processor!
-
         # if all roots finished and at least one failed, the run failed
         if not unfinished_tasks and any(
             leaf_ti.state in {State.FAILED, State.UPSTREAM_FAILED} for leaf_ti in leaf_tis
         ):
             self.log.error('Marking run %s failed', self)
             self.set_state(State.FAILED)
-            dag.handle_callback(self, success=False, reason='task_failure', session=session)
+            if handle_callback:
+                dag.handle_callback(self, success=False, reason='task_failure', session=session)
+            else:
+                self._callback = callback_requests.DagCallbackRequest(
+                    full_filepath=dag.fileloc,
+                    dag_id=self.dag_id,
+                    execution_date=self.execution_date,
+                    is_failure_callback=True,
+                    msg='task_failure'
+                )
 
         # if all leafs succeeded and no unfinished tasks, the run succeeded
         elif not unfinished_tasks and all(
@@ -410,15 +422,32 @@ class DagRun(Base, LoggingMixin):
         ):
             self.log.info('Marking run %s successful', self)
             self.set_state(State.SUCCESS)
-            dag.handle_callback(self, success=True, reason='success', session=session)
+            if handle_callback:
+                dag.handle_callback(self, success=True, reason='success', session=session)
+            else:
+                self._callback = callback_requests.DagCallbackRequest(
+                    full_filepath=dag.fileloc,
+                    dag_id=self.dag_id,
+                    execution_date=self.execution_date,
+                    is_failure_callback=False,
+                    msg='success'
+                )
 
         # if *all tasks* are deadlocked, the run failed
         elif (unfinished_tasks and none_depends_on_past and
               none_task_concurrency and not are_runnable_tasks):
             self.log.error('Deadlock; marking run %s failed', self)
             self.set_state(State.FAILED)
-            dag.handle_callback(self, success=False, reason='all_tasks_deadlocked',
-                                session=session)
+            if handle_callback:
+                dag.handle_callback(self, success=False, reason='all_tasks_deadlocked', session=session)
+            else:
+                self._callback = callback_requests.DagCallbackRequest(
+                        full_filepath=dag.fileloc,
+                        dag_id=self.dag_id,
+                        execution_date=self.execution_date,
+                        is_failure_callback=True,
+                        msg='all_tasks_deadlocked'
+                    )
 
         # finally, if the roots aren't done, the dag is still running
         else:
@@ -598,3 +627,7 @@ class DagRun(Base, LoggingMixin):
             .all()
         )
         return dagruns
+
+    @property
+    def callback(self) -> Optional[callback_requests.CallbackRequest]:
+        return self._callback

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -101,12 +101,12 @@ class DagRun(Base, LoggingMixin):
         self.conf = conf or {}
         self.state = state
         self.run_type = run_type
-        self._callback: Optional[callback_requests.DagCallbackRequest] = None
+        self.callback: Optional[callback_requests.DagCallbackRequest] = None
         super().__init__()
 
     @orm.reconstructor
     def init_on_load(self):
-        self._callback: Optional[callback_requests.DagCallbackRequest] = None
+        self.callback: Optional[callback_requests.DagCallbackRequest] = None
 
     def __repr__(self):
         return (
@@ -409,7 +409,7 @@ class DagRun(Base, LoggingMixin):
             if handle_callback:
                 dag.handle_callback(self, success=False, reason='task_failure', session=session)
             else:
-                self._callback = callback_requests.DagCallbackRequest(
+                self.callback = callback_requests.DagCallbackRequest(
                     full_filepath=dag.fileloc,
                     dag_id=self.dag_id,
                     execution_date=self.execution_date,
@@ -426,7 +426,7 @@ class DagRun(Base, LoggingMixin):
             if handle_callback:
                 dag.handle_callback(self, success=True, reason='success', session=session)
             else:
-                self._callback = callback_requests.DagCallbackRequest(
+                self.callback = callback_requests.DagCallbackRequest(
                     full_filepath=dag.fileloc,
                     dag_id=self.dag_id,
                     execution_date=self.execution_date,
@@ -442,7 +442,7 @@ class DagRun(Base, LoggingMixin):
             if handle_callback:
                 dag.handle_callback(self, success=False, reason='all_tasks_deadlocked', session=session)
             else:
-                self._callback = callback_requests.DagCallbackRequest(
+                self.callback = callback_requests.DagCallbackRequest(
                     full_filepath=dag.fileloc,
                     dag_id=self.dag_id,
                     execution_date=self.execution_date,
@@ -628,7 +628,3 @@ class DagRun(Base, LoggingMixin):
             .all()
         )
         return dagruns
-
-    @property
-    def callback(self) -> Optional[callback_requests.DagCallbackRequest]:
-        return self._callback

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -368,3 +368,6 @@ STORE_DAG_CODE = conf.getboolean("core", "store_dag_code", fallback=STORE_SERIAL
 DONOT_MODIFY_HANDLERS = conf.getboolean('logging', 'donot_modify_handlers', fallback=False)
 
 ALLOW_FUTURE_EXEC_DATES = conf.getboolean('scheduler', 'allow_trigger_in_future', fallback=False)
+
+# Whether or not to check each dagrun against defined SLAs
+CHECK_SLAS = conf.getboolean('core', 'check_slas', fallback=True)

--- a/airflow/utils/callback_requests.py
+++ b/airflow/utils/callback_requests.py
@@ -1,0 +1,95 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from datetime import datetime
+from typing import Optional
+
+from airflow.models.taskinstance import SimpleTaskInstance
+
+
+class CallbackRequest:
+    """
+    Base Class with information about the callback to be executed.
+
+    :param full_filepath: File Path to use to run the callback
+    :param msg: Additional Message that can be used for logging
+    """
+
+    def __init__(self, full_filepath: str, msg: Optional[str] = None):
+        self.full_filepath = full_filepath
+        self.msg = msg
+
+
+class TaskCallbackRequest(CallbackRequest):
+    """
+    A Class with information about the success/failure TI callback to be executed. Currently, only failure
+    callbacks (when tasks are externally killed) and Zombies are run via DagFileProcessorProcess.
+
+    :param full_filepath: File Path to use to run the callback
+    :param simple_task_instance: Simplified Task Instance representation
+    :param is_failure_callback: Flag to determine whether it is a Failure Callback or Success Callback
+    :param msg: Additional Message that can be used for logging to determine failure/zombie
+    """
+
+    def __init__(
+        self,
+        full_filepath: str,
+        simple_task_instance: SimpleTaskInstance,
+        is_failure_callback: Optional[bool] = True,
+        msg: Optional[str] = None
+    ):
+        super().__init__(full_filepath=full_filepath, msg=msg)
+        self.simple_task_instance = simple_task_instance
+        self.is_failure_callback = is_failure_callback
+
+
+class DagCallbackRequest(CallbackRequest):
+    """
+    A Class with information about the is_failure_callback/failure DAG callback to be executed.
+
+    :param full_filepath: File Path to use to run the callback
+    :param dag_id: DAG ID
+    :param execution_date: Execution Date for the DagRun
+    :param is_failure_callback: Flag to determine whether it is a Failure Callback or Success Callback
+    :param msg: Additional Message that can be used for logging
+    """
+
+    def __init__(
+        self,
+        full_filepath: str,
+        dag_id: str,
+        execution_date: datetime,
+        is_failure_callback: Optional[bool] = True,
+        msg: Optional[str] = None
+    ):
+        super().__init__(full_filepath=full_filepath, msg=msg)
+        self.dag_id = dag_id
+        self.execution_date = execution_date
+        self.is_failure_callback = is_failure_callback
+
+
+class SlaCallbackRequest(CallbackRequest):
+    """
+    A class with information about the SLA callback to be executed.
+
+    :param full_filepath: File Path to use to run the callback
+    :param dag_id: DAG ID
+    """
+
+    def __init__(self, full_filepath: str, dag_id: str):
+        super().__init__(full_filepath)
+        self.dag_id = dag_id

--- a/airflow/utils/callback_requests.py
+++ b/airflow/utils/callback_requests.py
@@ -33,6 +33,12 @@ class CallbackRequest:
         self.full_filepath = full_filepath
         self.msg = msg
 
+    def __eq__(self, other):
+        return self.__dict__ == other.__dict__
+
+    def __repr__(self):
+        return str(self.__dict__)
+
 
 class TaskCallbackRequest(CallbackRequest):
     """

--- a/airflow/utils/callback_requests.py
+++ b/airflow/utils/callback_requests.py
@@ -65,7 +65,7 @@ class TaskCallbackRequest(CallbackRequest):
 
 class DagCallbackRequest(CallbackRequest):
     """
-    A Class with information about the is_failure_callback/failure DAG callback to be executed.
+    A Class with information about the success/failure DAG callback to be executed.
 
     :param full_filepath: File Path to use to run the callback
     :param dag_id: DAG ID

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -2119,7 +2119,7 @@ class TestSchedulerJob(unittest.TestCase):
         )
 
         # Verify dag failure callback request is sent to file processor
-        scheduler.processor_agent.send_callback_to_execute.assert_called_once_with(dr._callback)
+        scheduler.processor_agent.send_callback_to_execute.assert_called_once_with(dr.callback)
 
         session.rollback()
         session.close()
@@ -2179,7 +2179,7 @@ class TestSchedulerJob(unittest.TestCase):
         )
 
         # Verify dag failure callback request is sent to file processor
-        scheduler.processor_agent.send_callback_to_execute.assert_called_once_with(dr._callback)
+        scheduler.processor_agent.send_callback_to_execute.assert_called_once_with(dr.callback)
 
         session.rollback()
         session.close()

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -46,7 +46,8 @@ from airflow.operators.bash import BashOperator
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.serialization.serialized_objects import SerializedDAG
 from airflow.utils import timezone
-from airflow.utils.dag_processing import FailureCallbackRequest, SimpleDagBag
+from airflow.utils.callback_requests import DagCallbackRequest, TaskCallbackRequest
+from airflow.utils.dag_processing import SimpleDagBag
 from airflow.utils.dates import days_ago
 from airflow.utils.file import list_py_file_paths
 from airflow.utils.session import create_session, provide_session
@@ -662,13 +663,13 @@ class TestDagFileProcessor(unittest.TestCase):
             session.commit()
 
             requests = [
-                FailureCallbackRequest(
+                TaskCallbackRequest(
                     full_filepath="A",
                     simple_task_instance=SimpleTaskInstance(ti),
                     msg="Message"
                 )
             ]
-            dag_file_processor.execute_on_callbacks(dagbag, requests)
+            dag_file_processor.execute_callbacks(dagbag, requests)
             mock_ti_handle_failure.assert_called_once_with(
                 "Message",
                 conf.getboolean('core', 'unit_test_mode'),
@@ -692,7 +693,7 @@ class TestDagFileProcessor(unittest.TestCase):
             session.commit()
 
             requests = [
-                FailureCallbackRequest(
+                TaskCallbackRequest(
                     full_filepath=dag.full_filepath,
                     simple_task_instance=SimpleTaskInstance(ti),
                     msg="Message"
@@ -974,8 +975,9 @@ class TestSchedulerJob(unittest.TestCase):
             old_children)
         self.assertFalse(current_children)
 
+    @mock.patch('airflow.jobs.scheduler_job.TaskCallbackRequest')
     @mock.patch('airflow.jobs.scheduler_job.Stats.incr')
-    def test_process_executor_events(self, mock_stats_incr):
+    def test_process_executor_events(self, mock_stats_incr, mock_task_callback):
         dag_id = "test_process_executor_events"
         dag_id2 = "test_process_executor_events_2"
         task_id_1 = 'dummy_task'
@@ -988,6 +990,8 @@ class TestSchedulerJob(unittest.TestCase):
         dag2.fileloc = "/test_path1/"
 
         executor = MockExecutor(do_update=False)
+        task_callback = mock.MagicMock()
+        mock_task_callback.return_value = task_callback
         scheduler = SchedulerJob(executor=executor)
         scheduler.processor_agent = mock.MagicMock()
 
@@ -1005,14 +1009,15 @@ class TestSchedulerJob(unittest.TestCase):
         scheduler._process_executor_events(session=session)
         ti1.refresh_from_db()
         self.assertEqual(ti1.state, State.QUEUED)
-        scheduler.processor_agent.send_callback_to_execute.assert_called_once_with(
+        mock_task_callback.assert_called_once_with(
             full_filepath='/test_path1/',
-            task_instance=mock.ANY,
+            simple_task_instance=mock.ANY,
             msg='Executor reports task instance '
                 '<TaskInstance: test_process_executor_events.dummy_task 2016-01-01 00:00:00+00:00 [queued]> '
                 'finished (failed) although the task says its queued. (Info: None) '
                 'Was the task killed externally?'
         )
+        scheduler.processor_agent.send_callback_to_execute.assert_called_once_with(task_callback)
         scheduler.processor_agent.reset_mock()
 
         # ti in success state
@@ -2100,14 +2105,26 @@ class TestSchedulerJob(unittest.TestCase):
         assert isinstance(orm_dag.next_dagrun, datetime.datetime)
         assert isinstance(orm_dag.next_dagrun_create_after, datetime.datetime)
 
-        # TODO[HA] Verify dag failure callback request sent to file processor
+        # Verify dag failure callback request is added to dagrun._callback
+        assert dr._callback is not None
+        assert isinstance(dr._callback, DagCallbackRequest)
+        assert dr._callback.msg == "timed_out"
+        assert dr._callback.dag_id == dr.dag_id
+        assert dr._callback.is_failure_callback
+        assert dr._callback.execution_date == dr.execution_date
+
+        # Verify dag failure callback request is sent to file processor
+        scheduler.processor_agent = mock.Mock()
+        scheduler.processor_agent.send_callback_to_execute = mock.Mock()
+        scheduler._send_dag_callbacks_to_processor(dr)
+        scheduler.processor_agent.send_callback_to_execute.assert_called_once_with(dr._callback)
 
         session.rollback()
         session.close()
 
     def test_dagrun_timeout_fails_run(self):
         """
-        Test if a a dagrun wil be set failed if timeout, even without max_active_runs
+        Test if a a dagrun will be set failed if timeout, even without max_active_runs
         """
         dag = DAG(
             dag_id='test_scheduler_fail_dagrun_timeout',
@@ -2133,7 +2150,7 @@ class TestSchedulerJob(unittest.TestCase):
         scheduler._create_dag_run(orm_dag, dag, session)
 
         drs = DagRun.find(dag_id=dag.dag_id, session=session)
-        assert len(drs) == 1 
+        assert len(drs) == 1
         dr = drs[0]
 
         # Should be scheduled as dagrun_timeout has passed
@@ -2146,7 +2163,19 @@ class TestSchedulerJob(unittest.TestCase):
         session.refresh(dr)
         assert dr.state == State.FAILED
 
-        # TODO[HA] Verify dag failure callback request sent to file processor
+        # Verify dag failure callback request is added to dagrun._callback
+        assert dr._callback is not None
+        assert isinstance(dr._callback, DagCallbackRequest)
+        assert dr._callback.msg == "timed_out"
+        assert dr._callback.dag_id == dr.dag_id
+        assert dr._callback.is_failure_callback
+        assert dr._callback.execution_date == dr.execution_date
+
+        # Verify dag failure callback request is sent to file processor
+        scheduler.processor_agent = mock.Mock()
+        scheduler.processor_agent.send_callback_to_execute = mock.Mock()
+        scheduler._send_dag_callbacks_to_processor(dr)
+        scheduler.processor_agent.send_callback_to_execute.assert_called_once_with(dr._callback)
 
         session.rollback()
         session.close()

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -668,7 +668,7 @@ class TestDagFileProcessor(unittest.TestCase):
                     msg="Message"
                 )
             ]
-            dag_file_processor.execute_on_failure_callbacks(dagbag, requests)
+            dag_file_processor.execute_on_callbacks(dagbag, requests)
             mock_ti_handle_failure.assert_called_once_with(
                 "Message",
                 conf.getboolean('core', 'unit_test_mode'),
@@ -721,7 +721,7 @@ class TestDagFileProcessor(unittest.TestCase):
         dagbag.sync_to_db()
 
         serialized_dags, import_errors_count = dag_file_processor.process_file(
-            file_path=dag_file, failure_callback_requests=[]
+            file_path=dag_file, callback_requests=[]
         )
 
         dags = [SerializedDAG.from_dict(serialized_dag) for serialized_dag in serialized_dags]
@@ -751,7 +751,7 @@ class TestDagFileProcessor(unittest.TestCase):
                 self.assertIsNone(duration)
 
         dag_file_processor.process_file(
-            file_path=dag_file, failure_callback_requests=[]
+            file_path=dag_file, callback_requests=[]
         )
         with create_session() as session:
             tis = session.query(TaskInstance).all()

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -2105,13 +2105,14 @@ class TestSchedulerJob(unittest.TestCase):
         assert isinstance(orm_dag.next_dagrun, datetime.datetime)
         assert isinstance(orm_dag.next_dagrun_create_after, datetime.datetime)
 
-        # Verify dag failure callback request is added to dagrun._callback
-        assert dr._callback is not None
-        assert isinstance(dr._callback, DagCallbackRequest)
-        assert dr._callback.msg == "timed_out"
-        assert dr._callback.dag_id == dr.dag_id
-        assert dr._callback.is_failure_callback
-        assert dr._callback.execution_date == dr.execution_date
+        # Verify dag failure callback request is added to dagrun.callback
+        assert dr.callback == DagCallbackRequest(
+            full_filepath=dr.dag.fileloc,
+            dag_id=dr.dag_id,
+            is_failure_callback=True,
+            execution_date=dr.execution_date,
+            msg="timed_out"
+        )
 
         # Verify dag failure callback request is sent to file processor
         scheduler.processor_agent = mock.Mock()
@@ -2163,13 +2164,14 @@ class TestSchedulerJob(unittest.TestCase):
         session.refresh(dr)
         assert dr.state == State.FAILED
 
-        # Verify dag failure callback request is added to dagrun._callback
-        assert dr._callback is not None
-        assert isinstance(dr._callback, DagCallbackRequest)
-        assert dr._callback.msg == "timed_out"
-        assert dr._callback.dag_id == dr.dag_id
-        assert dr._callback.is_failure_callback
-        assert dr._callback.execution_date == dr.execution_date
+        # Verify dag failure callback request is added to dagrun.callback
+        assert dr.callback == DagCallbackRequest(
+            full_filepath=dr.dag.fileloc,
+            dag_id=dr.dag_id,
+            is_failure_callback=True,
+            execution_date=dr.execution_date,
+            msg="timed_out"
+        )
 
         # Verify dag failure callback request is sent to file processor
         scheduler.processor_agent = mock.Mock()

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -2096,6 +2096,10 @@ class TestSchedulerJob(unittest.TestCase):
         dr.start_date = timezone.utcnow() - datetime.timedelta(days=1)
         session.flush()
 
+        # Mock that processor_agent is started
+        scheduler.processor_agent = mock.Mock()
+        scheduler.processor_agent.send_callback_to_execute = mock.Mock()
+
         scheduler._schedule_dag_run(dr, session)
         session.flush()
 
@@ -2115,9 +2119,6 @@ class TestSchedulerJob(unittest.TestCase):
         )
 
         # Verify dag failure callback request is sent to file processor
-        scheduler.processor_agent = mock.Mock()
-        scheduler.processor_agent.send_callback_to_execute = mock.Mock()
-        scheduler._send_dag_callbacks_to_processor(dr)
         scheduler.processor_agent.send_callback_to_execute.assert_called_once_with(dr._callback)
 
         session.rollback()
@@ -2158,6 +2159,10 @@ class TestSchedulerJob(unittest.TestCase):
         dr.start_date = timezone.utcnow() - datetime.timedelta(days=1)
         session.flush()
 
+        # Mock that processor_agent is started
+        scheduler.processor_agent = mock.Mock()
+        scheduler.processor_agent.send_callback_to_execute = mock.Mock()
+
         scheduler._schedule_dag_run(dr, session)
         session.flush()
 
@@ -2174,9 +2179,6 @@ class TestSchedulerJob(unittest.TestCase):
         )
 
         # Verify dag failure callback request is sent to file processor
-        scheduler.processor_agent = mock.Mock()
-        scheduler.processor_agent.send_callback_to_execute = mock.Mock()
-        scheduler._send_dag_callbacks_to_processor(dr)
         scheduler.processor_agent.send_callback_to_execute.assert_called_once_with(dr._callback)
 
         session.rollback()

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -394,7 +394,7 @@ class TestDagRun(unittest.TestCase):
         dag_run = self.create_dag_run(dag=dag, state=State.RUNNING, task_states=initial_task_states)
         self.assertIsNone(dag_run.callback)
 
-        dag_run.update_state(handle_callback=False)
+        dag_run.update_state(execute_callbacks=False)
         self.assertEqual(State.SUCCESS, dag_run.state)
         # Callbacks are not added until handle_callback = False is passed to dag_run.update_state()
 
@@ -434,7 +434,7 @@ class TestDagRun(unittest.TestCase):
         dag_run = self.create_dag_run(dag=dag, state=State.RUNNING, task_states=initial_task_states)
         self.assertIsNone(dag_run.callback)
 
-        dag_run.update_state(handle_callback=False)
+        dag_run.update_state(execute_callbacks=False)
         self.assertEqual(State.FAILED, dag_run.state)
         # Callbacks are not added until handle_callback = False is passed to dag_run.update_state()
 

--- a/tests/models/test_dagrun.py
+++ b/tests/models/test_dagrun.py
@@ -28,6 +28,7 @@ from airflow.models.dagrun import DagRun
 from airflow.operators.dummy_operator import DummyOperator
 from airflow.operators.python import ShortCircuitOperator
 from airflow.utils import timezone
+from airflow.utils.callback_requests import DagCallbackRequest
 from airflow.utils.state import State
 from airflow.utils.trigger_rule import TriggerRule
 from airflow.utils.types import DagRunType
@@ -329,6 +330,8 @@ class TestDagRun(unittest.TestCase):
                                       task_states=initial_task_states)
         dag_run.update_state()
         self.assertEqual(State.SUCCESS, dag_run.state)
+        # Callbacks are not added until handle_callback = False is passed to dag_run.update_state()
+        self.assertIsNone(dag_run.callback)
 
     def test_dagrun_failure_callback(self):
         def on_failure_callable(context):
@@ -360,6 +363,88 @@ class TestDagRun(unittest.TestCase):
                                       task_states=initial_task_states)
         dag_run.update_state()
         self.assertEqual(State.FAILED, dag_run.state)
+        # Callbacks are not added until handle_callback = False is passed to dag_run.update_state()
+        self.assertIsNone(dag_run.callback)
+
+    def test_dagrun_update_state_with_handle_callback_success(self):
+        def on_success_callable(context):
+            self.assertEqual(
+                context['dag_run'].dag_id,
+                'test_dagrun_update_state_with_handle_callback_success'
+            )
+
+        dag = DAG(
+            dag_id='test_dagrun_update_state_with_handle_callback_success',
+            start_date=datetime.datetime(2017, 1, 1),
+            on_success_callback=on_success_callable,
+        )
+        dag_task1 = DummyOperator(
+            task_id='test_state_succeeded1',
+            dag=dag)
+        dag_task2 = DummyOperator(
+            task_id='test_state_succeeded2',
+            dag=dag)
+        dag_task1.set_downstream(dag_task2)
+
+        initial_task_states = {
+            'test_state_succeeded1': State.SUCCESS,
+            'test_state_succeeded2': State.SUCCESS,
+        }
+
+        dag_run = self.create_dag_run(dag=dag, state=State.RUNNING, task_states=initial_task_states)
+        self.assertIsNone(dag_run.callback)
+
+        dag_run.update_state(handle_callback=False)
+        self.assertEqual(State.SUCCESS, dag_run.state)
+        # Callbacks are not added until handle_callback = False is passed to dag_run.update_state()
+
+        assert dag_run.callback == DagCallbackRequest(
+            full_filepath=dag_run.dag.fileloc,
+            dag_id="test_dagrun_update_state_with_handle_callback_success",
+            execution_date=dag_run.execution_date,
+            is_failure_callback=False,
+            msg="success"
+        )
+
+    def test_dagrun_update_state_with_handle_callback_failure(self):
+        def on_failure_callable(context):
+            self.assertEqual(
+                context['dag_run'].dag_id,
+                'test_dagrun_update_state_with_handle_callback_failure'
+            )
+
+        dag = DAG(
+            dag_id='test_dagrun_update_state_with_handle_callback_failure',
+            start_date=datetime.datetime(2017, 1, 1),
+            on_failure_callback=on_failure_callable,
+        )
+        dag_task1 = DummyOperator(
+            task_id='test_state_succeeded1',
+            dag=dag)
+        dag_task2 = DummyOperator(
+            task_id='test_state_failed2',
+            dag=dag)
+        dag_task1.set_downstream(dag_task2)
+
+        initial_task_states = {
+            'test_state_succeeded1': State.SUCCESS,
+            'test_state_failed2': State.FAILED,
+        }
+
+        dag_run = self.create_dag_run(dag=dag, state=State.RUNNING, task_states=initial_task_states)
+        self.assertIsNone(dag_run.callback)
+
+        dag_run.update_state(handle_callback=False)
+        self.assertEqual(State.FAILED, dag_run.state)
+        # Callbacks are not added until handle_callback = False is passed to dag_run.update_state()
+
+        assert dag_run.callback == DagCallbackRequest(
+            full_filepath=dag_run.dag.fileloc,
+            dag_id="test_dagrun_update_state_with_handle_callback_failure",
+            execution_date=dag_run.execution_date,
+            is_failure_callback=True,
+            msg="task_failure"
+        )
 
     def test_dagrun_set_state_end_date(self):
         session = settings.Session()

--- a/tests/utils/test_dag_processing.py
+++ b/tests/utils/test_dag_processing.py
@@ -216,6 +216,7 @@ class TestDagFileProcessorManager(unittest.TestCase):
             self.assertEqual(1, len(requests))
             self.assertEqual(requests[0].full_filepath, dag.full_filepath)
             self.assertEqual(requests[0].msg, "Detected as zombie")
+            self.assertEqual(requests[0].is_failure_callback, True)
             self.assertIsInstance(requests[0].simple_task_instance, SimpleTaskInstance)
             self.assertEqual(ti.dag_id, requests[0].simple_task_instance.dag_id)
             self.assertEqual(ti.task_id, requests[0].simple_task_instance.task_id)

--- a/tests/utils/test_dag_processing.py
+++ b/tests/utils/test_dag_processing.py
@@ -33,9 +33,9 @@ from airflow.jobs.scheduler_job import DagFileProcessorProcess
 from airflow.models import DagBag, DagModel, TaskInstance as TI
 from airflow.models.taskinstance import SimpleTaskInstance
 from airflow.utils import timezone
+from airflow.utils.callback_requests import TaskCallbackRequest
 from airflow.utils.dag_processing import (
     DagFileProcessorAgent, DagFileProcessorManager, DagFileStat, DagParsingSignal, DagParsingStat,
-    FailureCallbackRequest,
 )
 from airflow.utils.file import correct_maybe_zipped, open_maybe_zipped
 from airflow.utils.session import create_session
@@ -252,7 +252,7 @@ class TestDagFileProcessorManager(unittest.TestCase):
                 session.commit()
 
                 fake_failure_callback_requests = [
-                    FailureCallbackRequest(
+                    TaskCallbackRequest(
                         full_filepath=dag.full_filepath,
                         simple_task_instance=SimpleTaskInstance(ti),
                         msg="Message"


### PR DESCRIPTION
Remove all the callbacks (success, failure — both on Task & DAG) from the main Scheduler Loop. (use a base class for CallbackRequest for the DagProcessorProcess to run)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
