### PR TITLE
Modify celery worker deployment strategy 

### DIFF
--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -43,6 +43,9 @@ spec:
       tier: airflow
       component: worker
       release: {{ .Release.Name }}
+  {{ if .Values.workers.updateStrategy }}
+{{ toYaml .Values.workers.updateStrategy | indent 2 }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -186,6 +186,12 @@ workers:
   # Number of airflow celery workers in StatefulSet
   replicas: 1
 
+  updateStrategy:
+    strategy:
+      rollingUpdate:
+        maxSurge: "100%"
+        maxUnavailable: "50%"
+
   # Allow KEDA autoscaling.
   # Persistence.enabled must be set to false to use KEDA.
   keda:


### PR DESCRIPTION
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---

This PR modifies the worker template to allow passing a non-default deployment update strategy to worker deployments, in particular celery workers. The values have been set to allow 100% `maxSurge` and 50% `maxUnavailable` allowing new deployments of celery workers to launch a full set of replicas before the old set goes away. Allowing the new workers to pick up work as quickly as possible, rather than the current default which is 1 at a time. 

See the issue this closes for motivation and discussion 

closes: https://github.com/astronomer/issues/issues/1410


