### PR TITLE
Don’t run verify_integrity if the Serialized DAG hasn’t changed

### DIFF
--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -47,6 +47,7 @@ from airflow.jobs.base_job import BaseJob
 from airflow.models import DAG, DagModel, SlaMiss, errors
 from airflow.models.dagbag import DagBag
 from airflow.models.dagrun import DagRun
+from airflow.models.serialized_dag import SerializedDagModel
 from airflow.models.taskinstance import SimpleTaskInstance, TaskInstanceKey
 from airflow.stats import Stats
 from airflow.ti_deps.dependencies_states import EXECUTION_STATES
@@ -1557,8 +1558,7 @@ class SchedulerJob(BaseJob):  # pylint: disable=too-many-instance-attributes
             if currently_active_runs >= dag.max_active_runs:
                 return 0
 
-        # TODO[HA]: Run verify_integrity, but only if the serialized_dag has changed
-
+        self._verify_integrity_if_dag_changed(dag_run=dag_run, session=session)
         # TODO[HA]: Rename update_state -> schedule_dag_run, ?? something else?
         schedulable_tis = dag_run.update_state(session=session, execute_callbacks=False)
         # TODO[HA]: Don't return, update these from in update_state?
@@ -1569,6 +1569,23 @@ class SchedulerJob(BaseJob):  # pylint: disable=too-many-instance-attributes
         ).update({TI.state: State.SCHEDULED}, synchronize_session=False)
 
         return count
+
+    @provide_session
+    def _verify_integrity_if_dag_changed(self, dag_run: DagRun, session=None):
+        """Only run DagRun.verify integrity if Serialized DAG has changed since it is slow"""
+        latest_version = SerializedDagModel.get_latest_version_hash(dag_run.dag_id, session=session)
+        if dag_run.dag_version == latest_version:
+            self.log.debug("DAG Version not changed, skipping dagrun.verify_integrity")
+            return
+
+        dag_run.dag_version = latest_version
+
+        # Refresh the DAG
+        dag_run.dag = self.dagbag.get_dag(dag_id=dag_run.dag_id)
+        session.merge(dag_run)
+
+        # Verify integrity also takes care of session.flush
+        dag_run.verify_integrity(session=session)
 
     def _send_dag_callbacks_to_processor(self, dag_run: DagRun):
         if not self.processor_agent:

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1458,13 +1458,16 @@ class SchedulerJob(BaseJob):  # pylint: disable=too-many-instance-attributes
         Unconditionally create a DAG run for the given DAG, and update the dag_model's fields to control
         if/when the next DAGRun should be created
         """
+        dag_hash = self.dagbag.dags_hash.get(dag.dag_id, None)
+
         dag.create_dagrun(
             run_type=DagRunType.SCHEDULED,
             execution_date=dag_model.next_dagrun,
             start_date=timezone.utcnow(),
             state=State.RUNNING,
             external_trigger=False,
-            session=session
+            session=session,
+            dag_hash=dag_hash
         )
 
         self._update_dag_next_dagrun(dag_model, dag, session)

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -1574,15 +1574,14 @@ class SchedulerJob(BaseJob):  # pylint: disable=too-many-instance-attributes
     def _verify_integrity_if_dag_changed(self, dag_run: DagRun, session=None):
         """Only run DagRun.verify integrity if Serialized DAG has changed since it is slow"""
         latest_version = SerializedDagModel.get_latest_version_hash(dag_run.dag_id, session=session)
-        if dag_run.dag_version == latest_version:
-            self.log.debug("DAG Version not changed, skipping dagrun.verify_integrity")
+        if dag_run.dag_hash == latest_version:
+            self.log.debug("DAG %s not changed structure, skipping dagrun.verify_integrity", dag_run.dag_id)
             return
 
-        dag_run.dag_version = latest_version
+        dag_run.dag_hash = latest_version
 
         # Refresh the DAG
         dag_run.dag = self.dagbag.get_dag(dag_id=dag_run.dag_id)
-        session.merge(dag_run)
 
         # Verify integrity also takes care of session.flush
         dag_run.verify_integrity(session=session)

--- a/airflow/migrations/versions/98271e7606e2_add_scheduling_decision_to_dagrun_and_.py
+++ b/airflow/migrations/versions/98271e7606e2_add_scheduling_decision_to_dagrun_and_.py
@@ -39,7 +39,7 @@ def upgrade():
     with op.batch_alter_table('dag_run', schema=None) as batch_op:
         batch_op.add_column(sa.Column('last_scheduling_decision', sa.DateTime(timezone=True), nullable=True))
         batch_op.create_index('idx_last_scheduling_decision', ['last_scheduling_decision'], unique=False)
-        batch_op.add_column(sa.Column('dag_version', sa.String(32), nullable=True))
+        batch_op.add_column(sa.Column('dag_hash', sa.String(32), nullable=True))
 
     with op.batch_alter_table('dag', schema=None) as batch_op:
         batch_op.add_column(sa.Column('next_dagrun', sa.DateTime(timezone=True), nullable=True))
@@ -72,7 +72,7 @@ def downgrade():
     with op.batch_alter_table('dag_run', schema=None) as batch_op:
         batch_op.drop_index('idx_last_scheduling_decision')
         batch_op.drop_column('last_scheduling_decision')
-        batch_op.drop_column('dag_version')
+        batch_op.drop_column('dag_hash')
 
     with op.batch_alter_table('dag', schema=None) as batch_op:
         batch_op.drop_index('idx_next_dagrun_create_after')

--- a/airflow/migrations/versions/98271e7606e2_add_scheduling_decision_to_dagrun_and_.py
+++ b/airflow/migrations/versions/98271e7606e2_add_scheduling_decision_to_dagrun_and_.py
@@ -39,6 +39,7 @@ def upgrade():
     with op.batch_alter_table('dag_run', schema=None) as batch_op:
         batch_op.add_column(sa.Column('last_scheduling_decision', sa.DateTime(timezone=True), nullable=True))
         batch_op.create_index('idx_last_scheduling_decision', ['last_scheduling_decision'], unique=False)
+        batch_op.add_column(sa.Column('dag_version', sa.String(32), nullable=True))
 
     with op.batch_alter_table('dag', schema=None) as batch_op:
         batch_op.add_column(sa.Column('next_dagrun', sa.DateTime(timezone=True), nullable=True))
@@ -71,6 +72,7 @@ def downgrade():
     with op.batch_alter_table('dag_run', schema=None) as batch_op:
         batch_op.drop_index('idx_last_scheduling_decision')
         batch_op.drop_column('last_scheduling_decision')
+        batch_op.drop_column('dag_version')
 
     with op.batch_alter_table('dag', schema=None) as batch_op:
         batch_op.drop_index('idx_next_dagrun_create_after')

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1636,6 +1636,7 @@ class DAG(BaseDag, LoggingMixin):
         :param session: database session
         :type session: sqlalchemy.orm.session.Session
         """
+        from airflow.models.serialized_dag import SerializedDagModel
         if run_id and not run_type:
             if not isinstance(run_id, str):
                 raise ValueError(f"`run_id` expected to be a str is {type(run_id)}")
@@ -1658,6 +1659,7 @@ class DAG(BaseDag, LoggingMixin):
             conf=conf,
             state=state,
             run_type=run_type.value,
+            dag_version=SerializedDagModel.get_latest_version_hash(self.dag_id, session=session)
         )
         session.add(run)
 

--- a/airflow/models/dag.py
+++ b/airflow/models/dag.py
@@ -1606,15 +1606,18 @@ class DAG(BaseDag, LoggingMixin):
         args.func(args, self)
 
     @provide_session
-    def create_dagrun(self,
-                      state,
-                      execution_date=None,
-                      run_id=None,
-                      start_date=None,
-                      external_trigger=False,
-                      conf=None,
-                      run_type=None,
-                      session=None):
+    def create_dagrun(
+        self,
+        state,
+        execution_date=None,
+        run_id=None,
+        start_date=None,
+        external_trigger=False,
+        conf=None,
+        run_type=None,
+        session=None,
+        dag_hash=None
+    ):
         """
         Creates a dag run from this dag including the tasks associated with this dag.
         Returns the dag run.
@@ -1635,8 +1638,9 @@ class DAG(BaseDag, LoggingMixin):
         :type conf: dict
         :param session: database session
         :type session: sqlalchemy.orm.session.Session
+        :param dag_hash: Hash of Serialized DAG
+        :type dag_hash: str
         """
-        from airflow.models.serialized_dag import SerializedDagModel
         if run_id and not run_type:
             if not isinstance(run_id, str):
                 raise ValueError(f"`run_id` expected to be a str is {type(run_id)}")
@@ -1659,7 +1663,7 @@ class DAG(BaseDag, LoggingMixin):
             conf=conf,
             state=state,
             run_type=run_type.value,
-            dag_version=SerializedDagModel.get_latest_version_hash(self.dag_id, session=session)
+            dag_hash=dag_hash
         )
         session.add(run)
 

--- a/airflow/models/dagbag.py
+++ b/airflow/models/dagbag.py
@@ -116,6 +116,8 @@ class DagBag(BaseDagBag, LoggingMixin):
         self.read_dags_from_db = read_dags_from_db
         # Only used by read_dags_from_db=True
         self.dags_last_fetched: Dict[str, datetime] = {}
+        # Only used by SchedulerJob to compare the dag_hash to identify change in DAGs
+        self.dags_hash: Dict[str, str] = {}
 
         self.collect_dags(
             dag_folder=dag_folder,
@@ -219,6 +221,7 @@ class DagBag(BaseDagBag, LoggingMixin):
             self.dags[subdag.dag_id] = subdag
         self.dags[dag.dag_id] = dag
         self.dags_last_fetched[dag.dag_id] = timezone.utcnow()
+        self.dags_hash[dag.dag_id] = row.dag_hash
 
     def process_file(self, filepath, only_if_updated=True, safe_mode=True):
         """

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -63,7 +63,7 @@ class DagRun(Base, LoggingMixin):
     conf = Column(PickleType)
     # When a scheduler last attempted to schedule TIs for this DagRun
     last_scheduling_decision = Column(UtcDateTime)
-    dag_version = Column(String(32))
+    dag_hash = Column(String(32))
 
     dag = None
 
@@ -103,7 +103,7 @@ class DagRun(Base, LoggingMixin):
         self.conf = conf or {}
         self.state = state
         self.run_type = run_type
-        self.dag_version = dag_version
+        self.dag_hash = dag_version
         self.callback: Optional[callback_requests.DagCallbackRequest] = None
         super().__init__()
 

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -93,7 +93,7 @@ class DagRun(Base, LoggingMixin):
         conf: Optional[Any] = None,
         state: Optional[str] = None,
         run_type: Optional[str] = None,
-        dag_version: Optional[str] = None,
+        dag_hash: Optional[str] = None,
     ):
         self.dag_id = dag_id
         self.run_id = run_id
@@ -103,7 +103,7 @@ class DagRun(Base, LoggingMixin):
         self.conf = conf or {}
         self.state = state
         self.run_type = run_type
-        self.dag_hash = dag_version
+        self.dag_hash = dag_hash
         self.callback: Optional[callback_requests.DagCallbackRequest] = None
         super().__init__()
 

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -63,6 +63,7 @@ class DagRun(Base, LoggingMixin):
     conf = Column(PickleType)
     # When a scheduler last attempted to schedule TIs for this DagRun
     last_scheduling_decision = Column(UtcDateTime)
+    dag_version = Column(String(32))
 
     dag = None
 
@@ -91,7 +92,8 @@ class DagRun(Base, LoggingMixin):
         external_trigger: Optional[bool] = None,
         conf: Optional[Any] = None,
         state: Optional[str] = None,
-        run_type: Optional[str] = None
+        run_type: Optional[str] = None,
+        dag_version: Optional[str] = None,
     ):
         self.dag_id = dag_id
         self.run_id = run_id
@@ -101,6 +103,7 @@ class DagRun(Base, LoggingMixin):
         self.conf = conf or {}
         self.state = state
         self.run_type = run_type
+        self.dag_version = dag_version
         self.callback: Optional[callback_requests.DagCallbackRequest] = None
         super().__init__()
 
@@ -578,7 +581,7 @@ class DagRun(Base, LoggingMixin):
             self.log.info('Hit IntegrityError while creating the TIs for '
                           f'{dag.dag_id} - {self.execution_date}.')
             self.log.info('Doing session rollback.')
-            # TODO[HA]: We probaly need to savepoint this so we can keep the transaction alive.
+            # TODO[HA]: We probably need to savepoint this so we can keep the transaction alive.
             session.rollback()
 
     @staticmethod

--- a/airflow/models/serialized_dag.py
+++ b/airflow/models/serialized_dag.py
@@ -264,3 +264,18 @@ class SerializedDagModel(Base):
         :type session: Session
         """
         return session.query(cls.last_updated).filter(cls.dag_id == dag_id).scalar()
+
+    @classmethod
+    @provide_session
+    def get_latest_version_hash(cls, dag_id: str, session: Session = None) -> str:
+        """
+        Get the latest DAG version for a given DAG ID.
+
+        :param dag_id: DAG ID
+        :type dag_id: str
+        :param session: ORM Session
+        :type session: Session
+        :return: DAG Hash
+        :rtype: str
+        """
+        return session.query(cls.dag_hash).filter(cls.dag_id == dag_id).scalar()

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -911,6 +911,7 @@ class TestSchedulerJob(unittest.TestCase):
         clear_db_dags()
         clear_db_sla_miss()
         clear_db_errors()
+        clear_db_serialized_dags()
 
         # Speed up some tests by not running the tasks, just look at what we
         # enqueue!
@@ -2723,9 +2724,8 @@ class TestSchedulerJob(unittest.TestCase):
         orm_dag = session.query(DagModel).get(dag.dag_id)
         assert orm_dag is not None
 
-        dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
-
         scheduler = SchedulerJob()
+        dag = scheduler.dagbag.get_dag('test_verify_integrity_if_dag_not_changed', session=session)
         scheduler._create_dag_run(orm_dag, dag, session)
 
         drs = DagRun.find(dag_id=dag.dag_id, session=session)
@@ -2766,11 +2766,9 @@ class TestSchedulerJob(unittest.TestCase):
         orm_dag = session.query(DagModel).get(dag.dag_id)
         assert orm_dag is not None
 
-        dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
-
         scheduler = SchedulerJob()
+        dag = scheduler.dagbag.get_dag('test_verify_integrity_if_dag_changed', session=session)
         scheduler._create_dag_run(orm_dag, dag, session)
-        scheduler.dagbag.bag_dag(dag, root_dag=dag)
 
         drs = DagRun.find(dag_id=dag.dag_id, session=session)
         assert len(drs) == 1

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -2749,7 +2749,7 @@ class TestSchedulerJob(unittest.TestCase):
         assert tis_count == 1
 
         latest_dag_version = SerializedDagModel.get_latest_version_hash(dr.dag_id, session=session)
-        assert dr.dag_version == latest_dag_version
+        assert dr.dag_hash == latest_dag_version
 
         session.rollback()
         session.close()
@@ -2777,7 +2777,7 @@ class TestSchedulerJob(unittest.TestCase):
         dr = drs[0]
 
         dag_version_1 = SerializedDagModel.get_latest_version_hash(dr.dag_id, session=session)
-        assert dr.dag_version == dag_version_1
+        assert dr.dag_hash == dag_version_1
         assert scheduler.dagbag.dags == {'test_verify_integrity_if_dag_changed': dag}
         assert len(scheduler.dagbag.dags.get("test_verify_integrity_if_dag_changed").tasks) == 1
 
@@ -2796,7 +2796,7 @@ class TestSchedulerJob(unittest.TestCase):
         drs = DagRun.find(dag_id=dag.dag_id, session=session)
         assert len(drs) == 1
         dr = drs[0]
-        assert dr.dag_version == dag_version_2
+        assert dr.dag_hash == dag_version_2
         assert scheduler.dagbag.dags == {'test_verify_integrity_if_dag_changed': dag}
         assert len(scheduler.dagbag.dags.get("test_verify_integrity_if_dag_changed").tasks) == 2
 
@@ -2808,7 +2808,7 @@ class TestSchedulerJob(unittest.TestCase):
         assert tis_count == 2
 
         latest_dag_version = SerializedDagModel.get_latest_version_hash(dr.dag_id, session=session)
-        assert dr.dag_version == latest_dag_version
+        assert dr.dag_hash == latest_dag_version
 
         session.rollback()
         session.close()


### PR DESCRIPTION
dag_run.verify_integrity is slow, and we don't want to call it every time, just when the dag structure changes (which we can know now thanks to DAG Serialization)



<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
