### PR TITLE
Retry dagbag.sync_to_db on OperatorError

### DIFF
--- a/airflow/config_templates/config.yml
+++ b/airflow/config_templates/config.yml
@@ -549,6 +549,15 @@
       type: string
       example: "connexion,sqlalchemy"
       default: ""
+    - name: max_db_retries
+      description: |
+        Number of times the code should be retried in case of DB Operational Errors.
+        Not all transactions will be retried as it can cause undesired state.
+        Currently it is only used in ``DagFileProcessor.process_file`` to retry ``dagbag.sync_to_db``.
+      version_added: ~
+      type: int
+      example: ~
+      default: "3"
 - name: secrets
   description: ~
   options:

--- a/airflow/config_templates/default_airflow.cfg
+++ b/airflow/config_templates/default_airflow.cfg
@@ -300,6 +300,11 @@ task_log_reader = task
 # Example: extra_loggers = connexion,sqlalchemy
 extra_loggers =
 
+# Number of times the code should be retried in case of DB Operational Errors.
+# Not all transactions will be retried as it can cause undesired state.
+# Currently it is only used in ``DagFileProcessor.process_file`` to retry ``dagbag.sync_to_db``.
+max_db_retries = 3
+
 [secrets]
 # Full class name of secrets backend to enable (will precede env vars and metastore in search path)
 # Example: backend = airflow.providers.amazon.aws.secrets.systems_manager.SystemsManagerParameterStoreBackend

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -681,19 +681,20 @@ class DagFileProcessor(LoggingMixin):
         # Save individual DAGs in the ORM
         dagbag.read_dags_from_db = True
 
-        attempts = 3
-        attempt_num = 1
         for attempt in tenacity.Retrying(
             retry=tenacity.retry_if_exception_type(exception_types=OperationalError),
             wait=tenacity.wait_random_exponential(multiplier=0.5, max=5),
             stop=tenacity.stop_after_attempt(3),
-            before_sleep=tenacity.before_sleep_log(self.log, logging.INFO),
+            before_sleep=tenacity.before_sleep_log(self.log, logging.DEBUG),
+            reraise=True
         ):
             with attempt:
-                self.log.info(
-                    "Running dagbag.sync_to_db with retries. Try %d of %d", attempt_num, attempts)
+                self.log.debug(
+                    "Running dagbag.sync_to_db with retries. Try %d of %d",
+                    attempt.retry_state,
+                    attempt.retry_state.max_attempt_number
+                )
                 dagbag.sync_to_db()
-                attempt_num += 1
 
         if pickle_dags:
             paused_dag_ids = DagModel.get_paused_dag_ids(dag_ids=dagbag.dag_ids)

--- a/airflow/jobs/scheduler_job.py
+++ b/airflow/jobs/scheduler_job.py
@@ -683,11 +683,10 @@ class DagFileProcessor(LoggingMixin):
 
         # Retry 'dagbag.sync_to_db()' in case of any Operational Errors
         # In case of failures, provide_session handles rollback
-        max_retry_attempts = 3
         for attempt in tenacity.Retrying(
             retry=tenacity.retry_if_exception_type(exception_types=OperationalError),
             wait=tenacity.wait_random_exponential(multiplier=0.5, max=5),
-            stop=tenacity.stop_after_attempt(max_retry_attempts),
+            stop=tenacity.stop_after_attempt(settings.MAX_DB_RETRIES),
             before_sleep=tenacity.before_sleep_log(self.log, logging.DEBUG),
             reraise=True
         ):
@@ -695,7 +694,7 @@ class DagFileProcessor(LoggingMixin):
                 self.log.debug(
                     "Running dagbag.sync_to_db with retries. Try %d of %d",
                     attempt.retry_state.attempt_number,
-                    max_retry_attempts
+                    settings.MAX_DB_RETRIES
                 )
                 dagbag.sync_to_db()
 

--- a/airflow/settings.py
+++ b/airflow/settings.py
@@ -370,3 +370,10 @@ ALLOW_FUTURE_EXEC_DATES = conf.getboolean('scheduler', 'allow_trigger_in_future'
 
 # Whether or not to check each dagrun against defined SLAs
 CHECK_SLAS = conf.getboolean('core', 'check_slas', fallback=True)
+
+# Number of times, the code should be retried in case of DB Operational Errors
+# Retries are done using tenacity. Not all transactions should be retried as it can cause
+# undesired state.
+# Currently used in the following places:
+# `DagFileProcessor.process_file` to retry `dagbag.sync_to_db`
+MAX_DB_RETRIES = conf.getint('core', 'max_db_retries', fallback=3)

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -705,10 +705,13 @@ class TestDagFileProcessor(unittest.TestCase):
 
     @mock.patch("airflow.jobs.scheduler_job.DagBag")
     def test_process_file_should_retry_sync_to_db(self, mock_dagbag):
+        """Test that dagbag.sync_to_db is retried on OperationalError"""
         dag_file_processor = DagFileProcessor(dag_ids=[], log=mock.MagicMock())
 
         mock_dagbag.return_value.dags = {'example_dag': mock.ANY}
         op_error = OperationalError(statement=mock.ANY, params=mock.ANY, orig=mock.ANY)
+
+        # Mock error for the first 2 tries and a successful third try
         side_effect = [op_error, op_error, mock.ANY]
 
         mock_sync_to_db = mock.Mock(side_effect=side_effect)

--- a/tests/jobs/test_scheduler_job.py
+++ b/tests/jobs/test_scheduler_job.py
@@ -32,6 +32,7 @@ import six
 from mock import MagicMock, patch
 from parameterized import parameterized
 from sqlalchemy import func
+from sqlalchemy.exc import OperationalError
 
 import airflow.example_dags
 import airflow.smart_sensor_dags
@@ -701,6 +702,20 @@ class TestDagFileProcessor(unittest.TestCase):
                 content = callback_file2.read()
             self.assertEqual("Callback fired", content)
             os.remove(callback_file.name)
+
+    @mock.patch("airflow.jobs.scheduler_job.DagBag")
+    def test_process_file_should_retry_sync_to_db(self, mock_dagbag):
+        dag_file_processor = DagFileProcessor(dag_ids=[], log=mock.MagicMock())
+
+        mock_dagbag.return_value.dags = {'example_dag': mock.ANY}
+        op_error = OperationalError(statement=mock.ANY, params=mock.ANY, orig=mock.ANY)
+        side_effect = [op_error, op_error, mock.ANY]
+
+        mock_sync_to_db = mock.Mock(side_effect=side_effect)
+        mock_dagbag.return_value.sync_to_db = mock_sync_to_db
+
+        dag_file_processor.process_file("/dev/null", callback_requests=mock.MagicMock())
+        mock_sync_to_db.assert_has_calls([mock.call(), mock.call(), mock.call()])
 
     def test_should_mark_dummy_task_as_success(self):
         dag_file = os.path.join(


### PR DESCRIPTION
Tested it with docker-compose files, without this change MySQL 8 and 5.7 deadlocks, with this change it works fine after a single retry:

```
root@09fdc0b17ad4:/opt/airflow# grep -R "Retry" logs
logs/scheduler/latest/native_dags/example_dags/example_python_operator.py.log:[2020-10-06 16:48:05,771] {before_sleep.py:45} INFO - Retrying None in 0.345192396870534 seconds as it raised OperationalError: (_mysql_exceptions.OperationalError) (1213, 'Deadlock found when trying to get lock; try restarting transaction')
logs/scheduler/2020-10-06/native_dags/example_dags/example_python_operator.py.log:[2020-10-06 16:48:05,771] {before_sleep.py:45} INFO - Retrying None in 0.345192396870534 seconds as it raised OperationalError: (_mysql_exceptions.OperationalError) (1213, 'Deadlock found when trying to get lock; try restarting transaction')
```



```
logs/scheduler/2020-10-06/test_dag.py.log:[2020-10-06 16:54:29,022] {scheduler_job.py:667} INFO - Running dagbag.sync_to_db with retries. Try 1 of 3
logs/scheduler/2020-10-06/test_dag.py.log:[2020-10-06 16:54:30,464] {scheduler_job.py:667} INFO - Running dagbag.sync_to_db with retries. Try 1 of 3
```