### PR TITLE
Update to new helm stable repo

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -37,7 +37,7 @@ cluster using the [Helm](https://helm.sh) package manager.
 To install this repository from source (using helm 3)
 ```bash
 kubectl create namespace airflow
-helm repo add stable https://kubernetes-charts.storage.googleapis.com
+helm repo add stable https://charts.helm.sh/stable
 helm dep update
 helm install airflow . --namespace airflow
 ```

--- a/chart/requirements.lock
+++ b/chart/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  repository: https://charts.helm.sh/stable/
   version: 6.3.12
 digest: sha256:e8d53453861c590e6ae176331634c9268a11cf894be17ed580fa2b347101be97
 generated: "2020-10-27T21:16:13.0063538Z"

--- a/chart/tests/conftest.py
+++ b/chart/tests/conftest.py
@@ -27,6 +27,6 @@ def upgrade_helm():
     Upgrade Helm repo
     """
     subprocess.check_output(
-        ["helm", "repo", "add", "stable", "https://kubernetes-charts.storage.googleapis.com/"]
+        ["helm", "repo", "add", "stable", "https://charts.helm.sh/stable/"]
     )
     subprocess.check_output(["helm", "dep", "update", sys.path[0]])

--- a/scripts/ci/libraries/_kind.sh
+++ b/scripts/ci/libraries/_kind.sh
@@ -338,7 +338,7 @@ function kind::deploy_airflow_with_helm() {
     kubectl create namespace "${HELM_AIRFLOW_NAMESPACE}"
     kubectl create namespace "test-namespace"
     pushd "${AIRFLOW_SOURCES}/chart" || exit 1
-    helm repo add stable https://kubernetes-charts.storage.googleapis.com
+    helm repo add stable https://charts.helm.sh/stable
     helm dep update
     helm install airflow . --namespace "${HELM_AIRFLOW_NAMESPACE}" \
         --set "defaultAirflowRepository=${DOCKERHUB_USER}/${DOCKERHUB_REPO}" \


### PR DESCRIPTION
Switch out deprecated helm repo for new stable repo.

- <https://www.cncf.io/blog/2020/11/05/helm-chart-repository-deprecation-update/>
- <https://helm.sh/docs/faq/#i-am-getting-a-warning-about-unable-to-get-an-update-from-the-stable-chart-repository>

Relates to astronomer/issues#2003