### PR TITLE
Add setup.cfg for apache-airflow-upgrade-check

### DIFF
--- a/airflow/upgrade/README.md
+++ b/airflow/upgrade/README.md
@@ -1,0 +1,82 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+
+# Apache Airflow Upgrade Check
+
+[![PyPI version](https://badge.fury.io/py/apache-airflow-upgrade-check.svg)](https://badge.fury.io/py/apache-airflow-upgrade-check)
+[![License](http://img.shields.io/:license-Apache%202-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.txt)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/apache-airflow-upgrade-check.svg)](https://pypi.org/project/apache-airflow-upgrade-check/)
+[![PyPI - Downloads](https://img.shields.io/pypi/dm/apache-airflow-upgrade-check)](https://pypi.org/project/apache-airflow-upgrade-check/)
+[![Twitter Follow](https://img.shields.io/twitter/follow/ApacheAirflow.svg?style=social&label=Follow)](https://twitter.com/ApacheAirflow)
+[![Slack Status](https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social)](https://s.apache.org/airflow-slack)
+
+This package aims to easy the upgrade journey from [Apache Airflow](https://airflow.apache.org/) 1.10 to 2.0.
+
+While we have put a lot of effort in to making this upgrade as painless as possible, with many changes
+providing upgrade path (where the old code continues to work and prints out a deprecation warning) there were
+unfortunately some breaking changes where we couldn't provide a compatibility shim.
+
+The recommended upgrade path to get to Airflow 2.0.0 is to first upgrade to the latest release in the 1.10
+series (at the time of writing: 1.10.13) and to then run this script.
+
+```bash
+pip install apache-airflow-upgrade-check
+airflow upgrade_check
+```
+
+This will then print out a number of action items that you should follow before upgrading to 2.0.0 or above.
+
+The exit code of the command will be 0 (success) if no problems are reported, or 1 otherwise.
+
+For example:
+
+```
+============================================= STATUS =============================================
+
+Legacy UI is deprecated by default......................................................SUCCESS
+Users must set a kubernetes.pod_template_file value.....................................FAIL
+Changes in import paths of hooks, operators, sensors and others.........................FAIL
+Remove airflow.AirflowMacroPlugin class.................................................SUCCESS
+Jinja Template Variables cannot be undefined............................................SUCCESS
+Fernet is enabled by default............................................................FAIL
+Logging configuration has been moved to new section.....................................SUCCESS
+Connection.conn_id is not unique........................................................SUCCESS
+GCP service account key deprecation.....................................................SUCCESS
+Users must delete deprecated configs for KubernetesExecutor.............................FAIL
+Changes in import path of remote task handlers..........................................SUCCESS
+Chain between DAG and operator not allowed..............................................SUCCESS
+SendGrid email uses old airflow.contrib module..........................................SUCCESS
+Connection.conn_type is not nullable....................................................SUCCESS
+Found 16 problems.
+
+======================================== RECOMMENDATIONS =========================================
+
+Users must set a kubernetes.pod_template_file value
+---------------------------------------------------
+In Airflow 2.0, KubernetesExecutor Users need to set a pod_template_file as a base
+value for all pods launched by the KubernetesExecutor
+
+
+Problems:
+
+  1.  Please create a pod_template_file by running `airflow generate_pod_template`.
+This will generate a pod using your aiflow.cfg settings
+
+...
+```

--- a/airflow/upgrade/rules/mesos_executor_removed.py
+++ b/airflow/upgrade/rules/mesos_executor_removed.py
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from airflow.upgrade.rules.base_rule import BaseRule
+from airflow.configuration import conf
+
+
+class MesosExecutorRemovedRule(BaseRule):
+    """
+    MesosExecutorRemovedRule class to ease upgrade to Airflow 2.0
+    """
+    title = "Removal of Mesos Executor"
+    description = "The Mesos Executor has been deprecated as it was not widely used and not maintained."
+
+    def check(self):
+        executor_key = conf.get(section="core", key="executor")
+        if executor_key == "MesosExecutor":
+            return (
+                "The Mesos Executor has been deprecated as it was not widely used and not maintained."
+                "Please migrate to any of the supported executors."
+                "See https://airflow.apache.org/docs/stable/executor/index.html for more details."
+            )

--- a/airflow/upgrade/rules/undefined_jinja_varaibles.py
+++ b/airflow/upgrade/rules/undefined_jinja_varaibles.py
@@ -17,6 +17,7 @@
 
 from __future__ import absolute_import
 
+import logging
 import re
 
 import jinja2
@@ -131,8 +132,14 @@ The user should do either of the following to fix this -
 
     def check(self, dagbag=None):
         if not dagbag:
-            dag_folder = conf.get("core", "dags_folder")
-            dagbag = DagBag(dag_folder)
+            logger = logging.root
+            old_level = logger.level
+            try:
+                logger.setLevel(logging.ERROR)
+                dag_folder = conf.get("core", "dags_folder")
+                dagbag = DagBag(dag_folder)
+            finally:
+                logger.setLevel(old_level)
         dags = dagbag.dags
         messages = []
         for dag_id, dag in dags.items():

--- a/airflow/upgrade/setup.cfg
+++ b/airflow/upgrade/setup.cfg
@@ -59,3 +59,6 @@ zip_safe = no
 include =
   airflow.upgrade
   airflow.upgrade.*
+
+[bdist_wheel]
+universal=1

--- a/airflow/upgrade/setup.cfg
+++ b/airflow/upgrade/setup.cfg
@@ -1,0 +1,61 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[metadata]
+version=1.0.0
+name = apache-airflow-upgrade-check
+description = Check for compatibility between Airflow versions
+long_description = file: airflow/upgrade/README.md
+long_description_content_type = text/markdown
+url = https://airflow.apache.org
+author = Apache Airflow PMC
+author-email = dev@airflow.apache.org
+license = Apache License 2.0
+license_files =
+   LICENSE
+   NOTICE
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+keywords = airflow, upgrade
+project_urls =
+    Source Code=https://github.com/apache/airflow
+    Bug Tracker=https://github.com/apache/airflow/issues
+    Documentation=https://airflow.apache.org/docs/
+
+[options]
+packages = find:
+install_requires =
+    apache-airflow>=1.10.13,<3
+    importlib-metadata~=2.0; python_version<"3.8"
+    packaging
+python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*
+setup_requires =
+    setuptools>=40.0
+    wheel
+zip_safe = no
+
+[options.packages.find]
+include =
+  airflow.upgrade
+  airflow.upgrade.*

--- a/setup.py
+++ b/setup.py
@@ -426,12 +426,14 @@ devel = [
     'flaky',
     'freezegun',
     'gitpython',
+    'importlib-metadata~=2.0; python_version<"3.8"',
     'ipdb',
     'jira',
     'mock;python_version<"3.3"',
     'mongomock',
     'moto==1.3.14',  # TODO - fix Datasync issues to get higher version of moto:
                      #        See: https://github.com/apache/airflow/issues/10985
+    'packaging',
     'parameterized',
     'paramiko',
     'pre-commit',
@@ -445,7 +447,7 @@ devel = [
     'pywinrm',
     'qds-sdk>=1.9.6',
     'requests_mock',
-    'yamllint'
+    'yamllint',
 ]
 ############################################################################################################
 # IMPORTANT NOTE!!!!!!!!!!!!!!!

--- a/tests/upgrade/rules/test_mesos_executor_removed.py
+++ b/tests/upgrade/rules/test_mesos_executor_removed.py
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from unittest import TestCase
+
+from airflow.upgrade.rules.mesos_executor_removed import MesosExecutorRemovedRule
+from tests.test_utils.config import conf_vars
+
+
+class TestMesosExecutorRemovedRule(TestCase):
+    @conf_vars({("core", "executor"): "MesosExecutor"})
+    def test_invalid_check(self):
+        rule = MesosExecutorRemovedRule()
+
+        assert isinstance(rule.description, str)
+        assert isinstance(rule.title, str)
+
+        msg = (
+            "The Mesos Executor has been deprecated as it was not widely used and not maintained."
+            "Please migrate to any of the supported executors."
+            "See https://airflow.apache.org/docs/stable/executor/index.html for more details."
+        )
+
+        response = rule.check()
+        assert response == msg
+
+    @conf_vars({("core", "executor"): "SequentialExecutor"})
+    def test_check(self):
+        rule = MesosExecutorRemovedRule()
+
+        assert isinstance(rule.description, str)
+        assert isinstance(rule.title, str)
+
+        response = rule.check()
+        assert response is None


### PR DESCRIPTION
Nothing currently uses this setup.cfg from this folder -- automation for
that will follow shortly.

Now that there is a place list deps for upgrade-check I have moved
`packaging` and `importlib_meta` to test_requires of the main dist.


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).