### PR TITLE
Show "Warning" to Users with Duplicate Connections

### DIFF
--- a/airflow/www_rbac/views.py
+++ b/airflow/www_rbac/views.py
@@ -354,6 +354,20 @@ class Airflow(AirflowBaseView):
                     filename=filename),
                 "error")
 
+        duplicate_connections = session.query(Connection.conn_id) \
+            .group_by(Connection.conn_id) \
+            .having(func.count() > 1)
+
+        for connection in duplicate_connections.all():
+            flash(Markup(
+                'Duplicate connections found with conn_id="{}". '
+                'This will raise an error from Airflow 2.0. '
+                'Details: <a href="https://s.apache.org/dbqfd">https://s.apache.org/dbqfd</a>'.format(
+                    connection.conn_id
+                )),
+                "warning"
+            )
+
         num_of_pages = int(math.ceil(num_of_all_dags / float(dags_per_page)))
 
         state_color_mapping = State.state_color.copy()


### PR DESCRIPTION
As written in apache#9067, Airflow 2.0 introduces a change that
requires that all Airflow connections be unique (whereas Airflow 1.10.x
technically supports two connections with the same name and
potentially the same values).

With this commit, we show "warning" in the Airflow UI for users
with duplicate connections

Preview:
![image](https://user-images.githubusercontent.com/8811558/100010309-fb224100-2dc7-11eb-9a52-563aeaae73bd.png)


<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
