### PR TITLE
Correctly parse (and copy) extras with python version to metadist

### DIFF
--- a/astronomer-certified-setup.py
+++ b/astronomer-certified-setup.py
@@ -38,6 +38,8 @@ def get_info_from_airflow_wheel(filepath):
         \s*
         ;
         \s*
+        # ( python_version etc.
+        ( (?P<condition> .* ) \s and \s*)?
         extra \s* == \s* '(?P<extra> .*? )'
         \s*
         $
@@ -48,7 +50,12 @@ def get_info_from_airflow_wheel(filepath):
         if not match:
             continue
 
-        extras[match['extra']].append(match['specifier'])
+        if match['condition']:
+            specifier = match['specifier'] + ' ; ' + match['condition']
+        else:
+            specifier = match['specifier']
+
+        extras[match['extra']].append(specifier)
 
     return extras, airflow_version
 


### PR DESCRIPTION
1.10.14 introduced some python version requirements on the
 `cryptography` extra, so this extra was not available in our AC dist
 (but thankfully the module was still installed.)

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
