### PR TITLE
Exclude Yarn.lock to disable dev dependency scan

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -29,6 +29,7 @@ graft scripts/upstart
 graft airflow/config_templates
 recursive-exclude airflow/www/node_modules *
 global-exclude __pycache__  *.pyc
+exclude airflow/www/yarn.lock
 include airflow/alembic.ini
 include airflow/api_connexion/openapi/v1.yaml
 include airflow/git_version


### PR DESCRIPTION
Currently the airflow wheel is built with the yarn.lock which is not actually used by the airflow itself. The scanners are identifying potential high security vulnerabilities. 

The fix is to exclude the yarn.lock by specifying in the manifest.in

Closes: https://github.com/astronomer/issues/issues/3085