### PR TITLE
Save full build info to JSON file

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -32,6 +32,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Install jq
+        run: |
+          sudo apt install --yes jq
       - uses: actions/setup-python@v2
         with:
           python-version: '3.7'
@@ -64,6 +67,16 @@ jobs:
           args: >
             -h "Cache-Control:no-cache,max-age=0"
             cp -a public-read -r "./**/*.build" gs://pip.astronomer.io/simple/astronomer-certified
+          cli: gsutil
+      - name: "Deploy '.build.json' file (containing full build info)"
+        uses: actions-hub/gcloud@330.0.0
+        env:
+          APPLICATION_CREDENTIALS: ${{secrets.ASTRONOMER_PROD}}
+          PROJECT_ID: ${{secrets.GCLOUD_PROJECT_ID}}
+        with:
+          args: >
+            -h "Cache-Control:no-cache,max-age=0"
+            cp -a public-read -r "./**/*.build.json" gs://pip.astronomer.io/simple/astronomer-certified
           cli: gsutil
       - name: Index Pages
         env:

--- a/scripts/ci/astronomer-qa-nightly-build.sh
+++ b/scripts/ci/astronomer-qa-nightly-build.sh
@@ -32,34 +32,49 @@ fi
 
 echo "Building and releasing a QA package"
 echo
-git fetch
+# This output can be very long, and is mostly useless
+git fetch >/dev/null
 
-NEW_VERSION="$(date +%Y%m%d)"
-sed -i -E "s/dev[0-9]+/dev${NEW_VERSION}/g" airflow/version.py
-sed -i -E "s/dev[0-9]+(\+astro)?/dev${NEW_VERSION}/g" setup.py
+DATE_STRING="$(date +%Y%m%d)"
+sed -i -E "s/dev[0-9]+/dev${DATE_STRING}/g" airflow/version.py
+sed -i -E "s/dev[0-9]+(\+astro)?/dev${DATE_STRING}/g" setup.py
 
 UPDATED_AIRFLOW_VERSION=$(awk '/version = /{print $NF}' setup.py | tr -d \')
 export UPDATED_AIRFLOW_VERSION
 echo "Updated Airflow Version: $UPDATED_AIRFLOW_VERSION"
 
-python3 setup.py --quiet compile_assets bdist_wheel --dist-dir dist/apache-airflow/
+AIRFLOW_DIST_DIR="dist/apache-airflow"
 
-ls -altr dist/*/*
+python3 setup.py --quiet compile_assets bdist_wheel --dist-dir "$AIRFLOW_DIST_DIR"
+
+# Get the package name
+# As long as there's only one, this will grab it
+AIRFLOW_PACKAGE_PATH=$(echo $AIRFLOW_DIST_DIR/apache_airflow-*.whl)
+# shellcheck disable=SC2034
+AIRFLOW_PACKAGE_NAME=$(basename "$AIRFLOW_PACKAGE_PATH")
+
+ls -altr $AIRFLOW_DIST_DIR/*
+
+AC_DIST_DIR="dist/astronomer-certified"
 
 # Build the astronomer-certified release from the matching apache-airflow wheel file
-python3 scripts/ci/astronomer-certified-setup.py bdist_wheel --dist-dir dist/astronomer-certified dist/apache-airflow/apache_airflow-*.whl
+python3 scripts/ci/astronomer-certified-setup.py bdist_wheel --dist-dir "$AC_DIST_DIR" "$AIRFLOW_PACKAGE_PATH"
 
-ls -altr dist/astronomer-certified/*
+ls -altr $AC_DIST_DIR/*
 
+# Get the package name
+# As long as there's only one, this will grab it
+AC_PACKAGE_PATH=$(echo $AC_DIST_DIR/astronomer_certified-*.whl)
+AC_PACKAGE_NAME=$(basename "$AC_PACKAGE_PATH")
 # Get the version of AC (Example 1.10.7.post7)
-CURRENT_AC_VERSION=$(echo dist/astronomer-certified/astronomer_certified-*.whl | sed -E 's|.*astronomer_certified-(.+)-py3-none-any.whl|\1|')
+CURRENT_AC_VERSION=$(echo "$AC_PACKAGE_NAME" | sed -E 's|.*astronomer_certified-(.+)-py3-none-any.whl|\1|')
 export CURRENT_AC_VERSION
 echo "AC Version: $CURRENT_AC_VERSION"
 
 # Get the version of Apache Airflow (Example 1.10.7)
-AIRFLOW_BASE_VESION=$(echo "$CURRENT_AC_VERSION" | sed -E 's|([0-9]+\.[0-9]+\.[0-9]+).*|\1|')
-export AIRFLOW_BASE_VESION
-echo "Airflow Base Version: $AIRFLOW_BASE_VESION"
+AIRFLOW_BASE_VERSION=$(echo "$CURRENT_AC_VERSION" | sed -E 's|([0-9]+\.[0-9]+\.[0-9]+).*|\1|')
+export AIRFLOW_BASE_VERSION
+echo "Airflow Base Version: $AIRFLOW_BASE_VERSION"
 
 # Store the latest version info in a separate file
 # Example: 'astronomer-certified/latest-1.10.7.build' contains '1.10.7.post7'

--- a/scripts/ci/astronomer-qa-nightly-build.sh
+++ b/scripts/ci/astronomer-qa-nightly-build.sh
@@ -23,26 +23,26 @@ AIRFLOW_VERSION=$(awk '/version =/{print $NF; exit}' setup.py | tr -d \')
 export AIRFLOW_VERSION
 echo "Current Version is: ${AIRFLOW_VERSION}"
 
-if [[ ${AIRFLOW_VERSION} == *"dev"* ]]; then
-    echo "Building and releasing a QA package"
-    echo
-    git fetch
-
-    NEW_VERSION="$(date +%Y%m%d)"
-    sed -i -E "s/dev[0-9]+/dev${NEW_VERSION}/g" airflow/version.py
-    sed -i -E "s/dev[0-9]+(\+astro)?/dev${NEW_VERSION}/g" setup.py
-
-    UPDATED_AIRFLOW_VERSION=$(awk '/version = /{print $NF}' setup.py | tr -d \')
-    export UPDATED_AIRFLOW_VERSION
-    echo "Updated Airflow Version: $UPDATED_AIRFLOW_VERSION"
-
-    python3 setup.py --quiet compile_assets bdist_wheel --dist-dir dist/apache-airflow/
-else
+if [[ ${AIRFLOW_VERSION} != *"dev"* ]]; then
     echo "Version does not contain 'dev' in airflow/version.py"
     echo "Skipping build and release process"
     echo
     exit 1
 fi
+
+echo "Building and releasing a QA package"
+echo
+git fetch
+
+NEW_VERSION="$(date +%Y%m%d)"
+sed -i -E "s/dev[0-9]+/dev${NEW_VERSION}/g" airflow/version.py
+sed -i -E "s/dev[0-9]+(\+astro)?/dev${NEW_VERSION}/g" setup.py
+
+UPDATED_AIRFLOW_VERSION=$(awk '/version = /{print $NF}' setup.py | tr -d \')
+export UPDATED_AIRFLOW_VERSION
+echo "Updated Airflow Version: $UPDATED_AIRFLOW_VERSION"
+
+python3 setup.py --quiet compile_assets bdist_wheel --dist-dir dist/apache-airflow/
 
 ls -altr dist/*/*
 


### PR DESCRIPTION
This PR tweaks the package build GHA workflow to not only publish a `latest-main.build` file, but also a `latest-main.build.json` file with additional ("full") build information in JSON format.

Ideally, I think, we should publish only one build info file, and it should include extensive information on the build environment, data source, and output artifacts/files. However, I implemented this as a separate JSON file just in case the `latest-main.build` file was an already established convention. Otherwise, I'm happy to switch entirely over to publishing just the JSON formatted file.

We also already have one consumer of the `latest-main.build` file: the [ap-airflow nightly builds](https://github.com/astronomer/ap-airflow/blob/1f3a73c5b46f02fdfb98e58c2982a29ab0698fc0/.circleci/config.yml.j2#L192). That should be easy enough to fix if we want to switch entirely over to the JSON build info file, since this PR was written to better support those nightly builds anyway.