### PR TITLE
Remove latest-main.build file

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -58,16 +58,6 @@ jobs:
         with:
           args: cp -a public-read -r ./dist/* gs://pip.astronomer.io/simple
           cli: gsutil
-      - name: "Deploy '.build' file (containing deployed version number)"
-        uses: actions-hub/gcloud@330.0.0
-        env:
-          APPLICATION_CREDENTIALS: ${{secrets.ASTRONOMER_PROD}}
-          PROJECT_ID: ${{secrets.GCLOUD_PROJECT_ID}}
-        with:
-          args: >
-            -h "Cache-Control:no-cache,max-age=0"
-            cp -a public-read -r "./**/*.build" gs://pip.astronomer.io/simple/astronomer-certified
-          cli: gsutil
       - name: "Deploy '.build.json' file (containing full build info)"
         uses: actions-hub/gcloud@330.0.0
         env:

--- a/scripts/ci/astronomer-qa-nightly-build.sh
+++ b/scripts/ci/astronomer-qa-nightly-build.sh
@@ -75,10 +75,9 @@ AIRFLOW_BASE_VERSION=$(echo "$CURRENT_AC_VERSION" | sed -E 's|([0-9]+\.[0-9]+\.[
 export AIRFLOW_BASE_VERSION
 echo "Airflow Base Version: $AIRFLOW_BASE_VERSION"
 
-# Store the latest version info in a separate file
+# Store the latest full build info, including the latest version, in a separate file
 # Example: 'astronomer-certified/latest-1.10.7.build' contains '1.10.7.post7'
 mkdir astronomer-certified
-echo "${CURRENT_AC_VERSION}" > astronomer-certified/latest-main.build
 
 # From https://stackoverflow.com/a/39896036
 # and https://stedolan.github.io/jq/manual/#$ENV,env


### PR DESCRIPTION
Follow up to #1424 - this removes the `latest-main.build` file, since it is unnecessary anymore.