### PR TITLE
Abstract task group children serialization 

### DIFF
--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -63,6 +63,7 @@ from airflow.models.pool import Pool
 from airflow.models.taskinstance import Context, TaskInstance, clear_task_instances
 from airflow.models.taskmixin import DAGNode, DependencyMixin
 from airflow.models.xcom import XCOM_RETURN_KEY
+from airflow.serialization.enums import DagAttributeTypes
 from airflow.ti_deps.deps.base_ti_dep import BaseTIDep
 from airflow.ti_deps.deps.not_in_retry_period_dep import NotInRetryPeriodDep
 from airflow.ti_deps.deps.not_previously_skipped_dep import NotPreviouslySkippedDep
@@ -1600,6 +1601,10 @@ class BaseOperator(Operator, LoggingMixin, DAGNode, metaclass=BaseOperatorMeta):
 
         return cls.__serialized_fields
 
+    def serialize_for_task_group(self) -> Tuple[DagAttributeTypes, Any]:
+        """Required by DAGNode."""
+        return DagAttributeTypes.OP, self.task_id
+
     def is_smart_sensor_compatible(self):
         """Return if this operator can use smart service. Default False."""
         return False
@@ -1740,6 +1745,10 @@ class MappedOperator(DAGNode):
 
     def has_dag(self):
         return self.dag is not None
+
+    def serialize_for_task_group(self) -> Tuple[DagAttributeTypes, Any]:
+        """Required by DAGNode."""
+        return DagAttributeTypes.OP, self.task_id
 
 
 # TODO: Deprecate for Airflow 3.0

--- a/airflow/models/taskmixin.py
+++ b/airflow/models/taskmixin.py
@@ -17,11 +17,12 @@
 
 import warnings
 from abc import ABCMeta, abstractmethod
-from typing import TYPE_CHECKING, Iterable, List, Optional, Sequence, Set, Union
+from typing import TYPE_CHECKING, Any, Iterable, List, Optional, Sequence, Set, Tuple, Union
 
 import pendulum
 
 from airflow.exceptions import AirflowException
+from airflow.serialization.enums import DagAttributeTypes
 
 if TYPE_CHECKING:
     from logging import Logger
@@ -263,3 +264,7 @@ class DAGNode(DependencyMixin, metaclass=ABCMeta):
             return self.upstream_list
         else:
             return self.downstream_list
+
+    def serialize_for_task_group(self) -> Tuple[DagAttributeTypes, Any]:
+        """This is used by SerializedTaskGroup to serialize a task group's content."""
+        raise NotImplementedError()

--- a/airflow/serialization/serialized_objects.py
+++ b/airflow/serialization/serialized_objects.py
@@ -21,7 +21,7 @@ import enum
 import logging
 from dataclasses import dataclass
 from inspect import Parameter, signature
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Set, Type, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Set, Type, Union
 
 import cattr
 import pendulum
@@ -973,10 +973,7 @@ class SerializedTaskGroup(TaskGroup, BaseSerialization):
             "ui_color": task_group.ui_color,
             "ui_fgcolor": task_group.ui_fgcolor,
             "children": {
-                label: (DAT.OP, child.task_id)
-                if isinstance(child, BaseOperator)
-                else (DAT.TASK_GROUP, SerializedTaskGroup.serialize_task_group(cast("TaskGroup", child)))
-                for label, child in task_group.children.items()
+                label: child.serialize_for_task_group() for label, child in task_group.children.items()
             },
             "upstream_group_ids": cls._serialize(sorted(task_group.upstream_group_ids)),
             "downstream_group_ids": cls._serialize(sorted(task_group.downstream_group_ids)),

--- a/airflow/utils/task_group.py
+++ b/airflow/utils/task_group.py
@@ -22,10 +22,11 @@ together when the DAG is displayed graphically.
 import copy
 import re
 import weakref
-from typing import TYPE_CHECKING, Any, Dict, Generator, Iterable, List, Optional, Sequence, Set, Union
+from typing import TYPE_CHECKING, Any, Dict, Generator, Iterable, List, Optional, Sequence, Set, Tuple, Union
 
 from airflow.exceptions import AirflowException, DuplicateTaskIdFound
 from airflow.models.taskmixin import DAGNode, DependencyMixin
+from airflow.serialization.enums import DagAttributeTypes
 from airflow.utils.helpers import validate_group_key
 from airflow.utils.types import NOTSET
 
@@ -385,6 +386,12 @@ class TaskGroup(DAGNode):
     def get_child_by_label(self, label: str) -> DAGNode:
         """Get a child task/TaskGroup by its label (i.e. task_id/group_id without the group_id prefix)"""
         return self.children[self.child_id(label)]
+
+    def serialize_for_task_group(self) -> Tuple[DagAttributeTypes, Any]:
+        """Required by DAGNode."""
+        from airflow.serialization.serialized_objects import SerializedTaskGroup
+
+        return DagAttributeTypes.TASK_GROUP, SerializedTaskGroup.serialize_task_group(self)
 
     def map(self, arg: Iterable) -> "MappedTaskGroup":
         if self.children:


### PR DESCRIPTION
This introduces a new function `serialize_for_task_group` to `DAGNode`, which should implement serialization logic when a `DAGNode` is put into a task group. Since all nodes belonging to a DAG are either the root group, or always in a parent task group, this guarantees a DAG's all nodes can be correctly serialized.