### PR TITLE
Fix scheduler_job_id type in executor

### DIFF
--- a/airflow/executors/base_executor.py
+++ b/airflow/executors/base_executor.py
@@ -17,7 +17,7 @@
 """Base executor - this is the base class for all the implemented executors."""
 import sys
 from collections import OrderedDict
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 from airflow.configuration import conf
 from airflow.models.taskinstance import TaskInstance, TaskInstanceKey
@@ -55,7 +55,7 @@ class BaseExecutor(LoggingMixin):
         ``0`` for infinity
     """
 
-    job_id: Optional[int] = None
+    job_id: Union[None, int, str] = None
 
     def __init__(self, parallelism: int = PARALLELISM):
         super().__init__()

--- a/airflow/kubernetes/pod_generator.py
+++ b/airflow/kubernetes/pod_generator.py
@@ -337,7 +337,7 @@ class PodGenerator:
         pod_override_object: Optional[k8s.V1Pod],
         base_worker_pod: k8s.V1Pod,
         namespace: str,
-        scheduler_job_id: int,
+        scheduler_job_id: str,
         run_id: Optional[str] = None,
     ) -> k8s.V1Pod:
         """
@@ -359,7 +359,7 @@ class PodGenerator:
             'try_number': str(try_number),
         }
         labels = {
-            'airflow-worker': make_safe_label_value(str(scheduler_job_id)),
+            'airflow-worker': make_safe_label_value(scheduler_job_id),
             'dag_id': make_safe_label_value(dag_id),
             'task_id': make_safe_label_value(task_id),
             'try_number': str(try_number),


### PR DESCRIPTION
`AirflowKubernetesScheduler` and `KubernetesJobWatcher` declaring `scheduler_job_id` as int is inconsistent to `KubernetesExecutor`, which can pass in str. So the declaration is changed to use str instead, and implementation is reviewed to make sure it works correctly.