### PR TITLE
Convert sync-perm command to click and make tests compatible.

### DIFF
--- a/airflow/cli/commands/sync_perm.py
+++ b/airflow/cli/commands/sync_perm.py
@@ -19,13 +19,14 @@
 import click
 
 from airflow.cli import airflow_cmd
-from airflow.www.app import cached_app
 
 
 @airflow_cmd.command("sync-perm")
 @click.option("--include-dags", is_flag=True, help="If passed, DAG specific permissions will also be synced.")
 def sync_perm(include_dags):
     """Update permissions for existing roles and optionally DAGs"""
+    from airflow.www.app import cached_app
+
     appbuilder = cached_app().appbuilder
     print('Updating actions and resources for all existing roles')
     # Add missing permissions for all the Base Views _before_ syncing/creating roles

--- a/airflow/cli/commands/sync_perm.py
+++ b/airflow/cli/commands/sync_perm.py
@@ -25,7 +25,7 @@ from airflow.www.app import cached_app
 @airflow_cmd.command("sync-perm")
 @click.option("--include-dags", is_flag=True, help="If passed, DAG specific permissions will also be synced.")
 def sync_perm(include_dags):
-    """Updates permissions for existing roles and DAGs"""
+    """Update permissions for existing roles and optionally DAGs"""
     appbuilder = cached_app().appbuilder
     print('Updating actions and resources for all existing roles')
     # Add missing permissions for all the Base Views _before_ syncing/creating roles

--- a/airflow/cli/commands/sync_perm.py
+++ b/airflow/cli/commands/sync_perm.py
@@ -17,6 +17,7 @@
 # under the License.
 """Sync permission command"""
 import click
+from rich import print
 
 from airflow.cli import airflow_cmd
 

--- a/tests/cli/commands/test_sync_perm_command.py
+++ b/tests/cli/commands/test_sync_perm_command.py
@@ -16,37 +16,59 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-import unittest
 from unittest import mock
 
+import pytest
+from click.testing import CliRunner
+
 from airflow.cli import cli_parser
+from airflow.cli.__main__ import airflow_cmd
 from airflow.cli.commands import sync_perm_command
 
 
-class TestCliSyncPerm(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.parser = cli_parser.get_parser()
+@pytest.fixture
+def setup_test(request):
+    if request.param == "click":
+        module = "airflow.cli.commands.sync_perm.cached_app"
+    else:
+        module = "airflow.cli.commands.sync_perm_command.cached_app"
 
-    @mock.patch("airflow.cli.commands.sync_perm_command.cached_app")
-    def test_cli_sync_perm(self, mock_cached_app):
-        appbuilder = mock_cached_app.return_value.appbuilder
+    with mock.patch(module) as mocked_cached_app:
+        appbuilder = mocked_cached_app.return_value.appbuilder
         appbuilder.sm = mock.Mock()
+        yield request.param, appbuilder
 
-        args = self.parser.parse_args(['sync-perm'])
-        sync_perm_command.sync_perm(args)
+
+class TestCliSyncPerm:
+    @pytest.mark.parametrize("setup_test", ["click", "argparse"], indirect=True)
+    def test_cli_sync_perm_1(self, setup_test):
+        parser, appbuilder = setup_test
+        cli_args = ['sync-perm']
+
+        if parser == "click":
+            runner = CliRunner()
+            runner.invoke(airflow_cmd, cli_args)
+        else:
+            parser = cli_parser.get_parser()
+            args = parser.parse_args(cli_args)
+            sync_perm_command.sync_perm(args)
 
         appbuilder.add_permissions.assert_called_once_with(update_perms=True)
         appbuilder.sm.sync_roles.assert_called_once_with()
         appbuilder.sm.create_dag_specific_permissions.assert_not_called()
 
-    @mock.patch("airflow.cli.commands.sync_perm_command.cached_app")
-    def test_cli_sync_perm_include_dags(self, mock_cached_app):
-        appbuilder = mock_cached_app.return_value.appbuilder
-        appbuilder.sm = mock.Mock()
+    @pytest.mark.parametrize("setup_test", ["click", "argparse"], indirect=True)
+    def test_cli_sync_perm_include_dags(self, setup_test):
+        parser, appbuilder = setup_test
+        cli_args = ['sync-perm', '--include-dags']
 
-        args = self.parser.parse_args(['sync-perm', '--include-dags'])
-        sync_perm_command.sync_perm(args)
+        if parser == "click":
+            runner = CliRunner()
+            runner.invoke(airflow_cmd, cli_args)
+        else:
+            parser = cli_parser.get_parser()
+            args = parser.parse_args(cli_args)
+            sync_perm_command.sync_perm(args)
 
         appbuilder.add_permissions.assert_called_once_with(update_perms=True)
         appbuilder.sm.sync_roles.assert_called_once_with()


### PR DESCRIPTION
Related to https://github.com/apache/airflow/issues/22708 . This converts sync-perm command to use click. I have also used fixtures to ensure both click and argparse are tested along with reusing code wherever possible to avoid duplication. Please let me know if I am missing something as per the original PR to convert `db` command to click.

I left `cli_utils.action_cli` since I came across `ValueError` when using the decorator since it expects args to be non-empty though it's empty when using click.