### PR TITLE
Use local imports instead of toplevel imports to optimise startup time.

### DIFF
--- a/airflow/cli/commands/scheduler.py
+++ b/airflow/cli/commands/scheduler.py
@@ -36,12 +36,13 @@ from airflow.cli import (
     click_subdir,
 )
 from airflow.configuration import conf
-from airflow.jobs.scheduler_job import SchedulerJob
 from airflow.utils import cli as cli_utils
 from airflow.utils.cli import process_subdir, setup_locations, setup_logging, sigint_handler, sigquit_handler
 
 
 def _create_scheduler_job(subdir, num_runs, do_pickle):
+    from airflow.jobs.scheduler_job import SchedulerJob
+
     job = SchedulerJob(
         subdir=process_subdir(subdir),
         num_runs=num_runs,

--- a/airflow/cli/commands/standalone.py
+++ b/airflow/cli/commands/standalone.py
@@ -32,10 +32,6 @@ from termcolor import colored
 from airflow.cli import airflow_cmd
 from airflow.configuration import AIRFLOW_HOME, conf
 from airflow.executors import executor_constants
-from airflow.jobs.scheduler_job import SchedulerJob
-from airflow.jobs.triggerer_job import TriggererJob
-from airflow.utils import db
-from airflow.www.app import cached_app
 
 
 @airflow_cmd.command('standalone')
@@ -179,6 +175,8 @@ class StandaloneCommand:
     def initialize_database(self):
         """Makes sure all the tables are created."""
         # Set up DB tables
+        from airflow.utils import db
+
         self.print_output("standalone", "Checking database is initialized")
         db.initdb()
         self.print_output("standalone", "Database ready")
@@ -188,6 +186,8 @@ class StandaloneCommand:
         # server. Thus, we make a random password and store it in AIRFLOW_HOME,
         # with the reasoning that if you can read that directory, you can see
         # the database credentials anyway.
+        from airflow.www.app import cached_app
+
         appbuilder = cached_app().appbuilder
         user_exists = appbuilder.sm.find_user("admin")
         password_path = os.path.join(AIRFLOW_HOME, "standalone_admin_password.txt")
@@ -219,6 +219,9 @@ class StandaloneCommand:
         Detects when all Airflow components are ready to serve.
         For now, it's simply time-based.
         """
+        from airflow.jobs.scheduler_job import SchedulerJob
+        from airflow.jobs.triggerer_job import TriggererJob
+
         return (
             self.port_open(self.web_server_port)
             and self.job_running(SchedulerJob)

--- a/airflow/cli/commands/triggerer.py
+++ b/airflow/cli/commands/triggerer.py
@@ -25,7 +25,6 @@ from rich.console import Console
 
 from airflow import settings
 from airflow.cli import airflow_cmd, click_daemon, click_log_file, click_pid, click_stderr, click_stdout
-from airflow.jobs.triggerer_job import TriggererJob
 from airflow.utils import cli as cli_utils
 from airflow.utils.cli import setup_locations, setup_logging, sigint_handler, sigquit_handler
 
@@ -44,6 +43,8 @@ from airflow.utils.cli import setup_locations, setup_logging, sigint_handler, si
 @cli_utils.action_cli
 def triggerer(ctx, capacity, daemon_, log_file, pid, stderr, stdout):
     """Starts Airflow Triggerer"""
+    from airflow.jobs.triggerer_job import TriggererJob
+
     console = Console()
     settings.MASK_SECRETS_IN_LOGS = True
     console.print(settings.HEADER)

--- a/airflow/cli/commands/webserver.py
+++ b/airflow/cli/commands/webserver.py
@@ -51,7 +51,6 @@ from airflow.utils import cli as cli_utils
 from airflow.utils.cli import setup_locations, setup_logging
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.process_utils import check_if_pidfile_process_is_running
-from airflow.www.app import create_app
 
 log = logging.getLogger(__name__)
 
@@ -420,6 +419,8 @@ def webserver(
     """Starts Airflow Webserver"""
     console = Console()
     console.print(settings.HEADER)
+
+    from airflow.www.app import create_app
 
     # Check for old/insecure config, and fail safe (i.e. don't launch) if the config is wildly insecure.
     if conf.get('webserver', 'secret_key') == 'temporary_key':


### PR DESCRIPTION
This PR makes the cli to be in line with argparse implementation in terms of startup time. Since we register all subcommands by import in `__main__` trying to use one command might be slow due to unrelated command being slow as it does heavy import. For example using sync-perm might be slow because of webserver that imports `create_app` from `www`. The PR moves the imports to local imports so that the imports are done as needed. There is some code duplication due to local imports but it's worth the speedup.

Regarding `db` command the default value shown has `config_dict` imported and sorted at module level making the import of the file slow. I first tried making default as a callable but click just shows `dynamic` when a function is used. So I have resorted to using a class that emulates a callable to skip check and on `__str__` it returns the sorted tables. This ensures the `db cleanup --help` only evaluates the import.

A question I had was that in argparse the list is shown in help but no default is set meanwhile in click implementation the default is made as all_tables which means by default it cleans up all tables I suppose that might lead to surprising result compared to argparse.

| implementation  | startup time (seconds) | imports  |
|---|---|---|
|  argparse | 0.686  |  614 |
|  current | 2.327 | 2763  |
|  PR | 0.671 |  641 |

Argparse cli (0.686 seconds, 614 imports)

```
(.env) ➜  airflow git:(fix-imports) time python -Wignore -m airflow --help 2>&1 > /dev/null
python -Wignore -m airflow --help 2>&1 > /dev/null  0.64s user 0.04s system 99% cpu 0.686 total

(.env) ➜  airflow git:(convert-to-click-cli) python -X importtime -m airflow 2>&1 | grep 'import time' | wc   
    614    4300   40655
```

Before (2.327 seconds, 2763 imports)

```
(.env) ➜  airflow git:(convert-to-click-cli) time python -Wignore -m airflow.cli --help 2>&1 > /dev/null
python -Wignore -m airflow.cli --help 2>&1 > /dev/null  2.48s user 1.21s system 158% cpu 2.327 total

(.env) ➜  airflow git:(convert-to-click-cli) python -X importtime -m airflow.cli 2>&1 | grep 'import time' | wc
   2763   19343  230084
```

After (0.671 seconds, 641 imports)

```
(.env) ➜  airflow git:(fix-imports) time python -Wignore -m airflow.cli --help 2>&1 > /dev/null
python -Wignore -m airflow.cli --help 2>&1 > /dev/null  0.63s user 0.04s system 98% cpu 0.671 total

(.env) ➜  airflow git:(fix-imports) python -X importtime -m airflow.cli 2>&1 | grep 'import time' | wc
    641    4489   42185
```

click code that checks for default which the PR skips by making the class callable : 

https://github.com/pallets/click/blob/14472ffcd80dd86d47ddc08341168152540ee6f2/src/click/core.py#L2104-L2127

Code where default is formatted

https://github.com/pallets/click/blob/14472ffcd80dd86d47ddc08341168152540ee6f2/src/click/core.py#L2755-L2771