### PR TITLE
Pickle dag exception string fix

### DIFF
--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -236,7 +236,7 @@ def get_dag_by_pickle(pickle_id, session=None):
 
     dag_pickle = session.query(DagPickle).filter(DagPickle.id == pickle_id).first()
     if not dag_pickle:
-        raise AirflowException("Who hid the pickle!? [missing pickle]")
+        raise AirflowException(f"pickle_id cuold not be found in DagPickle.id list: {pickle_id}")
     pickle_dag = dag_pickle.pickle
     return pickle_dag
 

--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -236,7 +236,7 @@ def get_dag_by_pickle(pickle_id, session=None):
 
     dag_pickle = session.query(DagPickle).filter(DagPickle.id == pickle_id).first()
     if not dag_pickle:
-        raise AirflowException(f"pickle_id cuold not be found in DagPickle.id list: {pickle_id}")
+        raise AirflowException(f"pickle_id could not be found in DagPickle.id list: {pickle_id}")
     pickle_dag = dag_pickle.pickle
     return pickle_dag
 


### PR DESCRIPTION
In case of existing issue, reference it using one of the following:

closes: issue #199

Updating the `AirflowException` to include more context and add professionalism. 


from the notes in the issue
```
We should replace it with a better error message that does one or more of:

1. Describes the underlying issue ("Could not find picked dag with id '{pickle_id}' in database.")
2. Describes how this could have happened ("The dag may have been manually removed from the database {AIRFLOW_DAGS_TABLE}.")
3. Tries to give potential troubleshooting advice ("Ensure that the dag exists in '{AIRFLOW_DAGS_DIR}' and either wait a few minutes for the dags to get automatically reread and recreated, or restart the scheduler process:")
4. Possibly contains the commands for users to get back on their feet ("airflow scheduler restart")
(Please note that my environment variable and table names there are completely made up.)
```

I decided to use method 1