### PR TITLE
Add click-compatible cheat-sheet command

### DIFF
--- a/airflow/cli/__main__.py
+++ b/airflow/cli/__main__.py
@@ -18,6 +18,7 @@
 # under the License.
 
 from airflow.cli import airflow_cmd
+from airflow.cli.commands import cheat_sheet  # noqa: F401
 from airflow.cli.commands import db  # noqa: F401
 from airflow.cli.commands import scheduler  # noqa: F401
 from airflow.cli.commands import standalone  # noqa: F401

--- a/airflow/cli/commands/cheat_sheet.py
+++ b/airflow/cli/commands/cheat_sheet.py
@@ -1,0 +1,65 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import List, Optional
+
+import rich_click as click
+
+from airflow.cli import airflow_cmd, click_verbose
+from airflow.cli.simple_table import AirflowConsole, SimpleTable
+from airflow.utils.cli import suppress_logs_and_warning_click_compatible
+
+
+@airflow_cmd.command("cheat-sheet")
+@click_verbose
+@suppress_logs_and_warning_click_compatible
+def cheat_sheet(verbose):
+    """Display cheat-sheet"""
+    display_commands_index()
+
+
+def display_commands_index():
+    def display_recursive(
+        prefix: List[str],
+        command_group: click.Group,
+        help_msg: Optional[str] = None,
+        help_msg_length: int = 88,
+    ):
+        actions: List[click.Command] = []
+        groups: List[click.Group] = []
+        for command in command_group.commands.values():
+            if isinstance(command, click.Group):
+                groups.append(command)
+            else:
+                actions.append(command)
+
+        console = AirflowConsole()
+        if actions:
+            table = SimpleTable(title=help_msg or "Miscellaneous commands")
+            table.add_column(width=40)
+            table.add_column()
+            for action_command in sorted(actions, key=lambda d: d.name):
+                help_str = action_command.get_short_help_str(limit=help_msg_length)
+                table.add_row(" ".join([*prefix, action_command.name]), help_str)
+            console.print(table)
+
+        if groups:
+            for group_command in sorted(groups, key=lambda d: d.name):
+                group_prefix = [*prefix, group_command.name]
+                help_str = group_command.get_short_help_str(limit=help_msg_length)
+                display_recursive(group_prefix, group_command, help_str)
+
+    display_recursive(["airflow"], airflow_cmd)

--- a/airflow/cli/commands/cheat_sheet.py
+++ b/airflow/cli/commands/cheat_sheet.py
@@ -28,38 +28,35 @@ from airflow.utils.cli import suppress_logs_and_warning_click_compatible
 @suppress_logs_and_warning_click_compatible
 def cheat_sheet(verbose):
     """Display cheat-sheet"""
-    display_commands_index()
-
-
-def display_commands_index():
-    def display_recursive(
-        prefix: List[str],
-        command_group: click.Group,
-        help_msg: Optional[str] = None,
-        help_msg_length: int = 88,
-    ):
-        actions: List[click.Command] = []
-        groups: List[click.Group] = []
-        for command in command_group.commands.values():
-            if isinstance(command, click.Group):
-                groups.append(command)
-            else:
-                actions.append(command)
-
-        console = AirflowConsole()
-        if actions:
-            table = SimpleTable(title=help_msg or "Miscellaneous commands")
-            table.add_column(width=40)
-            table.add_column()
-            for action_command in sorted(actions, key=lambda d: d.name):
-                help_str = action_command.get_short_help_str(limit=help_msg_length)
-                table.add_row(" ".join([*prefix, action_command.name]), help_str)
-            console.print(table)
-
-        if groups:
-            for group_command in sorted(groups, key=lambda d: d.name):
-                group_prefix = [*prefix, group_command.name]
-                help_str = group_command.get_short_help_str(limit=help_msg_length)
-                display_recursive(group_prefix, group_command, help_str)
-
     display_recursive(["airflow"], airflow_cmd)
+
+
+def display_recursive(
+    prefix: List[str],
+    command_group: click.Group,
+    help_msg: Optional[str] = None,
+    help_msg_length: int = 88,
+):
+    actions: List[click.Command] = []
+    groups: List[click.Group] = []
+    for command in command_group.commands.values():
+        if isinstance(command, click.Group):
+            groups.append(command)
+        else:
+            actions.append(command)
+
+    console = AirflowConsole()
+    if actions:
+        table = SimpleTable(title=help_msg or "Miscellaneous commands")
+        table.add_column(width=40)
+        table.add_column()
+        for action_command in sorted(actions, key=lambda d: d.name):
+            help_str = action_command.get_short_help_str(limit=help_msg_length)
+            table.add_row(" ".join([*prefix, action_command.name]), help_str)
+        console.print(table)
+
+    if groups:
+        for group_command in sorted(groups, key=lambda d: d.name):
+            group_prefix = [*prefix, group_command.name]
+            help_str = group_command.get_short_help_str(limit=help_msg_length)
+            display_recursive(group_prefix, group_command, help_str)

--- a/airflow/cli/commands/db.py
+++ b/airflow/cli/commands/db.py
@@ -63,13 +63,13 @@ click_show_sql_only = click.option(
 @airflow_cmd.group()
 @click.pass_context
 def db(ctx):
-    """Commands for the metadata database"""
+    """Database operations"""
 
 
 @db.command('init')
 @click.pass_context
 def db_init(ctx):
-    """Initializes the metadata database"""
+    """Initialize the metadata database"""
     from airflow.utils import db as db_utils
 
     console = Console()
@@ -87,7 +87,7 @@ def db_init(ctx):
     help="This command will wait for up to this time, specified in seconds",
 )
 def check_migrations(ctx, migration_wait_timeout):
-    """Function to wait for all airflow migrations to complete. Used for launching airflow in k8s"""
+    """Wait for all airflow migrations to complete (used for launching airflow in k8s)"""
     from airflow.utils import db as db_utils
 
     console = Console()
@@ -289,11 +289,11 @@ def shell(ctx):
     '--migration-wait-timeout',
     type=int,
     default=60,
-    help="Tmeout to wait for the database to migrate",
+    help="Timeout to wait for the database to migrate",
 )
 @cli_utils.action_cli(check_db=False)
 def check(ctx, migration_wait_timeout):
-    """Runs a check command that checks if db is reachable"""
+    """Check if the database can be reached"""
     from airflow.utils import db as db_utils
 
     console = Console()
@@ -314,7 +314,7 @@ class _CleanTableDefault:
         return str(sorted(config_dict))
 
 
-@db.command('cleanup')
+@db.command('clean')
 @click.pass_context
 @click.option(
     '-t',

--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -335,6 +335,32 @@ def suppress_logs_and_warning(f: T) -> T:
     return cast(T, _wrapper)
 
 
+def suppress_logs_and_warning_click_compatible(f: T) -> T:
+    """
+    Click compatible version of suppress_logs_and_warning.
+    Place after click_verbose decorator.
+
+    Decorator to suppress logging and warning messages
+    in cli functions.
+    """
+
+    @functools.wraps(f)
+    def _wrapper(*args, **kwargs):
+        if kwargs.get("verbose"):
+            f(*args, **kwargs)
+        else:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                logging.disable(logging.CRITICAL)
+                try:
+                    f(*args, **kwargs)
+                finally:
+                    # logging output again depends on the effective
+                    # levels of individual loggers
+                    logging.disable(logging.NOTSET)
+
+    return cast(T, _wrapper)
+
 def get_config_with_source(include_default: bool = False) -> str:
     """Return configuration along with source for each option."""
     config_dict = conf.as_dict(display_source=True)

--- a/tests/cli/commands/test_cheat_sheet.py
+++ b/tests/cli/commands/test_cheat_sheet.py
@@ -1,0 +1,101 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import contextlib
+import io
+import unittest
+from typing import List
+
+import rich_click as click
+
+from airflow.cli.commands.cheat_sheet import display_recursive
+
+
+@click.group()
+def mock_cli():
+    """Mock cli"""
+    pass
+
+
+@mock_cli.group()
+def cmd_a():
+    """Help text A"""
+    pass
+
+
+@cmd_a.command("cmd_b")
+def cmd_b():
+    """Help text B"""
+    pass
+
+
+@cmd_a.command("cmd_c")
+def cmd_c():
+    """Help text C"""
+    pass
+
+
+@mock_cli.group()
+def cmd_e():
+    """Help text E"""
+    pass
+
+
+@cmd_e.command("cmd_f")
+def cmd_f():
+    """Help text F"""
+    pass
+
+
+@cmd_e.command("cmd_g")
+def cmd_g():
+    """Help text G"""
+    pass
+
+
+@mock_cli.command()
+def cmd_h():
+    """Help text H"""
+    pass
+
+
+SECTION_MISC = """\
+Miscellaneous commands                                 
+airflow cmd-h                             | Help text H
+"""
+
+SECTION_A = """\
+Help text A                                            
+airflow cmd-a cmd_b                       | Help text B
+airflow cmd-a cmd_c                       | Help text C
+"""
+
+SECTION_E = """\
+Help text E                                            
+airflow cmd-e cmd_f                       | Help text F
+airflow cmd-e cmd_g                       | Help text G
+"""
+
+
+class TestCheatSheet(unittest.TestCase):
+    def test_display_recursive_commands(self):
+        with contextlib.redirect_stdout(io.StringIO()) as stdout:
+            display_recursive(["airflow"], mock_cli)
+        output = stdout.getvalue()
+        assert SECTION_MISC in output
+        assert SECTION_A in output
+        assert SECTION_E in output


### PR DESCRIPTION
Related: #22708

### Summary

This PR adds the click-compatible `cheat_sheet` command. The new command **only references defined click commands**, so the current output is limited. As other commands are added, their names and doc-strings will appear in the output. This PR also updates a few doc-strings in the `commands/db` module to keep the help text consistent with the current CLI.

![Screen Shot 2022-04-13 at 8 27 53](https://user-images.githubusercontent.com/11639738/163070659-eb5eef81-d5fc-4ab2-b533-8fc7f530b1a7.png)

### How to test

```py
# click version
python airflow/cli cheat-sheet

# original version
airflow cheat-sheet
```