### PR TITLE
Add click-compatible jobs command

### DIFF
--- a/airflow/cli/__main__.py
+++ b/airflow/cli/__main__.py
@@ -22,6 +22,7 @@ from airflow.cli.commands import celery  # noqa: F401
 from airflow.cli.commands import cheat_sheet  # noqa: F401
 from airflow.cli.commands import db  # noqa: F401
 from airflow.cli.commands import info  # noqa: F401
+from airflow.cli.commands import jobs  # noqa: F401
 from airflow.cli.commands import scheduler  # noqa: F401
 from airflow.cli.commands import standalone  # noqa: F401
 from airflow.cli.commands import sync_perm  # noqa: F401

--- a/airflow/cli/commands/jobs.py
+++ b/airflow/cli/commands/jobs.py
@@ -1,0 +1,82 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import List
+
+import rich_click as click
+
+from airflow.cli import airflow_cmd
+from airflow.jobs.base_job import BaseJob
+from airflow.utils.session import provide_session
+from airflow.utils.state import State
+
+
+@airflow_cmd.group("jobs")
+def jobs():
+    """Manage jobs"""
+
+
+@jobs.command("check")
+@click.option(
+    "--job-type",
+    type=click.Choice({"BackfillJob", "LocalTaskJob", "SchedulerJob", "TriggererJob"}),
+    help="The type of job(s) that will be checked. By default all job types are checked.",
+)
+@click.option(
+    "--hostname", metavar="HOSTNAME", default=None, help="The hostname of job(s) that will be checked."
+)
+@click.option(
+    "--limit",
+    default=1,
+    type=click.IntRange(min=0, max=None),
+    help="The number of recent jobs that will be checked. To disable limit, set 0.",
+)
+@click.option(
+    "--allow-multiple",
+    is_flag=True,
+    default=False,
+    help="If passed, this command will be successful even if multiple matching alive jobs are found.",
+)
+@provide_session
+def check(job_type: str, hostname: str, limit: int, allow_multiple: bool, session=None):
+    """Checks if job(s) are still alive"""
+    if allow_multiple and not limit > 1:
+        raise SystemExit("To use option --allow-multiple, you must set the limit to a value greater than 1.")
+    query = (
+        session.query(BaseJob)
+        .filter(BaseJob.state == State.RUNNING)
+        .order_by(BaseJob.latest_heartbeat.desc())
+    )
+    if job_type:
+        query = query.filter(BaseJob.job_type == job_type)
+    if hostname:
+        query = query.filter(BaseJob.hostname == hostname)
+    if limit > 0:
+        query = query.limit(limit)
+
+    jobs: List[BaseJob] = query.all()
+    alive_jobs = [job for job in jobs if job.is_alive()]
+
+    count_alive_jobs = len(alive_jobs)
+    if count_alive_jobs == 0:
+        raise SystemExit("No alive jobs found.")
+    if count_alive_jobs > 1 and not allow_multiple:
+        raise SystemExit(f"Found {count_alive_jobs} alive jobs. Expected only one.")
+    if count_alive_jobs == 1:
+        print("Found one alive job.")
+    else:
+        print(f"Found {count_alive_jobs} alive jobs.")

--- a/airflow/cli/commands/jobs.py
+++ b/airflow/cli/commands/jobs.py
@@ -27,7 +27,18 @@ from airflow.utils.state import State
 
 @airflow_cmd.group("jobs")
 def jobs():
-    """Manage jobs"""
+    """Manage jobs
+
+    \b
+    Examples:
+    To check if the local scheduler is still working properly, run:
+    \b
+        $ airflow jobs check --job-type SchedulerJob --hostname "$(hostname)"
+    \b
+    To check if any scheduler is running when you are using high availability, run:
+    \b
+        $ airflow jobs check --job-type SchedulerJob --allow-multiple --limit 100
+    """
 
 
 @jobs.command("check")

--- a/airflow/cli/commands/jobs.py
+++ b/airflow/cli/commands/jobs.py
@@ -27,18 +27,7 @@ from airflow.utils.state import State
 
 @airflow_cmd.group("jobs")
 def jobs():
-    """Manage jobs
-
-    \b
-    Examples:
-    To check if the local scheduler is still working properly, run:
-    \b
-        $ airflow jobs check --job-type SchedulerJob --hostname "$(hostname)"
-    \b
-    To check if any scheduler is running when you are using high availability, run:
-    \b
-        $ airflow jobs check --job-type SchedulerJob --allow-multiple --limit 100
-    """
+    """Manage jobs"""
 
 
 @jobs.command("check")
@@ -64,7 +53,18 @@ def jobs():
 )
 @provide_session
 def check(job_type: str, hostname: str, limit: int, allow_multiple: bool, session=None):
-    """Checks if job(s) are still alive"""
+    """Checks if job(s) are still alive
+
+    \b
+    examples:
+    To check if the local scheduler is still working properly, run:
+    \b
+        $ airflow jobs check --job-type SchedulerJob --hostname "$(hostname)"
+    \b
+    To check if any scheduler is running when you are using high availability, run:
+    \b
+        $ airflow jobs check --job-type SchedulerJob --allow-multiple --limit 100
+    """
     if allow_multiple and not limit > 1:
         raise SystemExit("To use option --allow-multiple, you must set the limit to a value greater than 1.")
     query = (

--- a/tests/cli/commands/test_jobs.py
+++ b/tests/cli/commands/test_jobs.py
@@ -1,0 +1,129 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import unittest
+
+import pytest
+from click.testing import CliRunner
+
+from airflow.cli.commands import jobs
+from airflow.jobs.scheduler_job import SchedulerJob
+from airflow.utils.session import create_session
+from airflow.utils.state import State
+from tests.test_utils.db import clear_db_jobs
+
+
+class TestCliConfigList(unittest.TestCase):
+    def setUp(self) -> None:
+        clear_db_jobs()
+        self.scheduler_job = None
+
+    def tearDown(self) -> None:
+        if self.scheduler_job and self.scheduler_job.processor_agent:
+            self.scheduler_job.processor_agent.end()
+        clear_db_jobs()
+
+    def test_should_report_success_for_one_working_scheduler(self):
+        with create_session() as session:
+            self.scheduler_job = SchedulerJob()
+            self.scheduler_job.state = State.RUNNING
+            session.add(self.scheduler_job)
+            session.commit()
+            self.scheduler_job.heartbeat()
+
+        runner = CliRunner()
+        result = runner.invoke(jobs.check, ["--job-type", "SchedulerJob"])
+        self.assertIn("Found one alive job.", result.output)
+
+    def test_should_report_success_for_one_working_scheduler_with_hostname(self):
+        with create_session() as session:
+            self.scheduler_job = SchedulerJob()
+            self.scheduler_job.state = State.RUNNING
+            self.scheduler_job.hostname = 'HOSTNAME'
+            session.add(self.scheduler_job)
+            session.commit()
+            self.scheduler_job.heartbeat()
+
+        runner = CliRunner()
+        result = runner.invoke(jobs.check, ["--job-type", "SchedulerJob", "--hostname", "HOSTNAME"])
+        self.assertIn("Found one alive job.", result.output)
+
+    def test_should_report_success_for_ha_schedulers(self):
+        scheduler_jobs = []
+        with create_session() as session:
+            for _ in range(3):
+                scheduler_job = SchedulerJob()
+                scheduler_job.state = State.RUNNING
+                session.add(scheduler_job)
+                scheduler_jobs.append(scheduler_job)
+            session.commit()
+            scheduler_job.heartbeat()
+
+        runner = CliRunner()
+        result = runner.invoke(
+            jobs.check, ["--job-type", "SchedulerJob", "--limit", "100", "--allow-multiple"]
+        )
+        self.assertIn("Found 3 alive jobs.", result.output)
+        for scheduler_job in scheduler_jobs:
+            if scheduler_job.processor_agent:
+                scheduler_job.processor_agent.end()
+
+    def test_should_ignore_not_running_jobs(self):
+        scheduler_jobs = []
+        with create_session() as session:
+            for _ in range(3):
+                scheduler_job = SchedulerJob()
+                scheduler_job.state = State.SHUTDOWN
+                session.add(scheduler_job)
+                scheduler_jobs.append(scheduler_job)
+            session.commit()
+        # No alive jobs found.
+        runner = CliRunner()
+        result = runner.invoke(jobs.check)
+        assert isinstance(result.exception, SystemExit)
+        assert "No alive jobs found." in result.output
+        for scheduler_job in scheduler_jobs:
+            if scheduler_job.processor_agent:
+                scheduler_job.processor_agent.end()
+
+    def test_should_raise_exception_for_multiple_scheduler_on_one_host(self):
+        scheduler_jobs = []
+        with create_session() as session:
+            for _ in range(3):
+                scheduler_job = SchedulerJob()
+                scheduler_job.state = State.RUNNING
+                scheduler_job.hostname = 'HOSTNAME'
+                session.add(scheduler_job)
+            session.commit()
+            scheduler_job.heartbeat()
+
+        runner = CliRunner()
+        result = runner.invoke(jobs.check, ["--job-type", "SchedulerJob", "--limit", "100"])
+        assert isinstance(result.exception, SystemExit)
+        assert "Found 3 alive jobs. Expected only one." in result.output
+
+        for scheduler_job in scheduler_jobs:
+            if scheduler_job.processor_agent:
+                scheduler_job.processor_agent.end()
+
+    def test_should_raise_exception_for_allow_multiple_and_limit_1(self):
+        runner = CliRunner()
+        result = runner.invoke(jobs.check, ["--allow-multiple"])
+        assert isinstance(result.exception, SystemExit)
+        assert (
+            "To use option --allow-multiple, you must set the limit to a value greater than 1."
+            in result.output
+        )


### PR DESCRIPTION
Related: #22708

## Summary

This PR adds click-compatible `jobs check` command.

Todo:
- [x] add click command
- [x] update unit tests

## Screenshots (before/after)

<img width="1158" alt="Screen Shot 2022-06-15 at 8 55 35" src="https://user-images.githubusercontent.com/11639738/173708395-fa51cb86-25a5-4fcd-adcc-99904ce0eaf7.png">