### PR TITLE
Add click-compatible plugins command

### DIFF
--- a/airflow/cli/__main__.py
+++ b/airflow/cli/__main__.py
@@ -23,6 +23,7 @@ from airflow.cli.commands import cheat_sheet  # noqa: F401
 from airflow.cli.commands import db  # noqa: F401
 from airflow.cli.commands import info  # noqa: F401
 from airflow.cli.commands import jobs  # noqa: F401
+from airflow.cli.commands import plugins  # noqa: F401
 from airflow.cli.commands import scheduler  # noqa: F401
 from airflow.cli.commands import standalone  # noqa: F401
 from airflow.cli.commands import sync_perm  # noqa: F401

--- a/airflow/cli/commands/plugins.py
+++ b/airflow/cli/commands/plugins.py
@@ -28,7 +28,7 @@ from airflow.utils.cli import suppress_logs_and_warning_click_compatible
 @click_verbose
 @suppress_logs_and_warning_click_compatible
 def dump_plugins(output, verbose):
-    """Dump plugins information"""
+    """Dump information about loaded plugins"""
     plugins_info: List[Dict[str, str]] = get_plugin_info()
     console = AirflowConsole()
     if not plugins_manager.plugins:

--- a/airflow/cli/commands/plugins.py
+++ b/airflow/cli/commands/plugins.py
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from typing import Dict, List
+
+from airflow import plugins_manager
+from airflow.cli import airflow_cmd, click_output, click_verbose
+from airflow.cli.simple_table import AirflowConsole
+from airflow.plugins_manager import get_plugin_info
+from airflow.utils.cli import suppress_logs_and_warning_click_compatible
+
+
+@airflow_cmd.command("plugins")
+@click_output
+@click_verbose
+@suppress_logs_and_warning_click_compatible
+def dump_plugins(output, verbose):
+    """Dump plugins information"""
+    plugins_info: List[Dict[str, str]] = get_plugin_info()
+    console = AirflowConsole()
+    if not plugins_manager.plugins:
+        console.print("No plugins loaded")
+        return
+
+    # Remove empty info
+    if output == "table":
+        # We can do plugins_info[0] as the element it will exist as there's
+        # at least one plugin at this point
+        for col in list(plugins_info[0]):
+            if all(not bool(p[col]) for p in plugins_info):
+                for plugin in plugins_info:
+                    del plugin[col]
+
+    console.print_as(plugins_info, output=output)

--- a/airflow/utils/cli.py
+++ b/airflow/utils/cli.py
@@ -311,6 +311,9 @@ def suppress_logs_and_warning(f: T) -> T:
     """
     Decorator to suppress logging and warning messages
     in cli functions.
+
+    This function can be safely deleted after all Airflow CLI
+    commands are rewritten with Click (#22708)
     """
 
     @functools.wraps(f)

--- a/tests/cli/commands/test_plugins.py
+++ b/tests/cli/commands/test_plugins.py
@@ -1,0 +1,109 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import json
+import textwrap
+import unittest
+
+from click.testing import CliRunner
+
+from airflow.cli.commands import plugins
+from airflow.hooks.base import BaseHook
+from airflow.listeners.listener import get_listener_manager
+from airflow.plugins_manager import AirflowPlugin
+from tests.plugins.test_plugin import AirflowTestPlugin as ComplexAirflowPlugin
+from tests.test_utils.mock_plugins import mock_plugin_manager
+
+
+class PluginHook(BaseHook):
+    pass
+
+
+class TestPlugin(AirflowPlugin):
+    name = "test-plugin-cli"
+    hooks = [PluginHook]
+
+
+class TestPluginsCommand(unittest.TestCase):
+    def setUp(self) -> None:
+        self.runner = CliRunner()
+
+    @mock_plugin_manager(plugins=[])
+    def test_should_display_no_plugins(self):
+        result = self.runner.invoke(plugins.dump_plugins, ["--output=json"])
+        assert "No plugins loaded" in result.output
+
+    @mock_plugin_manager(plugins=[ComplexAirflowPlugin])
+    def test_should_display_one_plugins(self):
+        result = self.runner.invoke(plugins.dump_plugins, ["--output=json"])
+        print(result.output)
+        info = json.loads(result.output)
+        assert info == [
+            {
+                'name': 'test_plugin',
+                'macros': ['tests.plugins.test_plugin.plugin_macro'],
+                'executors': ['tests.plugins.test_plugin.PluginExecutor'],
+                'flask_blueprints': [
+                    "<flask.blueprints.Blueprint: name='test_plugin' import_name='tests.plugins.test_plugin'>"
+                ],
+                'appbuilder_views': [
+                    {
+                        'name': 'Test View',
+                        'category': 'Test Plugin',
+                        'view': 'tests.plugins.test_plugin.PluginTestAppBuilderBaseView',
+                    }
+                ],
+                'global_operator_extra_links': [
+                    '<tests.test_utils.mock_operators.AirflowLink object>',
+                    '<tests.test_utils.mock_operators.GithubLink object>',
+                ],
+                'timetables': ['tests.plugins.test_plugin.CustomCronDataIntervalTimetable'],
+                'operator_extra_links': [
+                    '<tests.test_utils.mock_operators.GoogleLink object>',
+                    '<tests.test_utils.mock_operators.AirflowLink2 object>',
+                    '<tests.test_utils.mock_operators.CustomOpLink object>',
+                    '<tests.test_utils.mock_operators.CustomBaseIndexOpLink object>',
+                ],
+                'hooks': ['tests.plugins.test_plugin.PluginHook'],
+                'listeners': ['tests.listeners.empty_listener'],
+                'source': None,
+                'appbuilder_menu_items': [
+                    {'name': 'Google', 'href': 'https://www.google.com', 'category': 'Search'},
+                    {
+                        'name': 'apache',
+                        'href': 'https://www.apache.org/',
+                        'label': 'The Apache Software Foundation',
+                    },
+                ],
+                'ti_deps': ['<TIDep(CustomTestTriggerRule)>'],
+            }
+        ]
+        get_listener_manager().clear()
+
+    @mock_plugin_manager(plugins=[TestPlugin])
+    def test_should_display_one_plugins_as_table(self):
+        result = self.runner.invoke(plugins.dump_plugins, ["--output=table"])
+        # Remove leading spaces
+        stdout = "\n".join(line.rstrip(" ") for line in result.output.splitlines())
+        # Assert that only columns with values are displayed
+        expected_output = textwrap.dedent(
+            """\
+            name            | hooks
+            ================+===========================================
+            test-plugin-cli | tests.cli.commands.test_plugins.PluginHook
+            """
+        )
+        self.assertEqual(stdout, expected_output)


### PR DESCRIPTION
Related: #22708

## Summary

This PR adds a click-compatible `plugins` command.

- [x] add click command
- [x] update unit tests

## Screenshots (before/after)

<img width="983" alt="Screen Shot 2022-06-17 at 9 44 19" src="https://user-images.githubusercontent.com/11639738/174200433-e82001be-7a82-4fa1-8110-0b1cd38219c3.png">