### PR TITLE
add dataset event table

### DIFF
--- a/airflow/example_dags/example_datasets.py
+++ b/airflow/example_dags/example_datasets.py
@@ -45,6 +45,11 @@ dag1_dataset = Dataset('s3://dag1/output_1.txt', extra={'hi': 'bye'})
 # [END dataset_def]
 dag2_dataset = Dataset('s3://dag2/output_1.txt', extra={'hi': 'bye'})
 
+
+def post_execute(context, result):
+    context['dataset_payload'] = {"hello": "goodbye"}
+
+
 dag1 = DAG(
     dag_id='dag1',
     catchup=False,
@@ -54,7 +59,13 @@ dag1 = DAG(
 )
 
 # [START task_outlet]
-BashOperator(outlets=[dag1_dataset], task_id='upstream_task_1', bash_command="sleep 5", dag=dag1)
+BashOperator(
+    outlets=[dag1_dataset],
+    task_id='upstream_task_1',
+    bash_command="sleep 5",
+    post_execute=post_execute,
+    dag=dag1,
+)
 # [END task_outlet]
 
 with DAG(
@@ -79,6 +90,7 @@ dag3 = DAG(
     tags=['downstream'],
 )
 # [END dag_dep]
+
 
 BashOperator(
     outlets=[Dataset('s3://downstream_1_task/dataset_other.txt')],

--- a/airflow/migrations/versions/0114_2_4_0_add_dataset_model.py
+++ b/airflow/migrations/versions/0114_2_4_0_add_dataset_model.py
@@ -118,12 +118,39 @@ def _create_dataset_dag_run_queue_table():
     )
 
 
+def _create_dataset_event_table():
+    op.create_table(
+        'dataset_event',
+        sa.Column('id', Integer, primary_key=True, autoincrement=True),
+        sa.Column('dataset_id', Integer, nullable=False),
+        sa.Column('extra', ExtendedJSON, nullable=True),
+        sa.Column('source_task_id', String(250), nullable=True),
+        sa.Column('source_dag_id', String(250), nullable=True),
+        sa.Column('source_run_id', String(250), nullable=True),
+        sa.Column('source_map_index', sa.Integer(), nullable=True, server_default='-1'),
+        sa.Column('created_at', TIMESTAMP, nullable=False),
+        sqlite_autoincrement=True,  # ensures PK values not reused
+    )
+    sa.ForeignKeyConstraint(
+        ('dataset_id',),
+        ['dataset.id'],
+        name="datasetevent_dataset_fkey",
+    ),
+    sa.ForeignKeyConstraint(
+        ('source_dag_run_id',),
+        ['dag_run.id'],
+        name="datasetevent_dagrun_fkey",
+    ),
+    op.create_index('idx_dataset_id_created_at', 'dataset_event', ['dataset_id', 'created_at'], unique=True)
+
+
 def upgrade():
     """Apply Add Dataset model"""
     _create_dataset_table()
     _create_dataset_dag_ref_table()
     _create_dataset_task_ref_table()
     _create_dataset_dag_run_queue_table()
+    _create_dataset_event_table()
 
 
 def downgrade():
@@ -131,4 +158,5 @@ def downgrade():
     op.drop_table('dataset_dag_ref')
     op.drop_table('dataset_task_ref')
     op.drop_table('dataset_dag_run_queue')
+    op.drop_table('dataset_event')
     op.drop_table('dataset')

--- a/airflow/migrations/versions/0114_2_4_0_add_dataset_model.py
+++ b/airflow/migrations/versions/0114_2_4_0_add_dataset_model.py
@@ -141,7 +141,9 @@ def _create_dataset_event_table():
         ['dag_run.id'],
         name="datasetevent_dagrun_fkey",
     ),
-    op.create_index('idx_dataset_id_created_at', 'dataset_event', ['dataset_id', 'created_at'], unique=True)
+    op.create_index(
+        'idx_dataset_id_created_at', 'dataset_event', ['dataset_id', 'created_at'], mssql_clustered=True
+    )
 
 
 def upgrade():

--- a/airflow/models/dataset.py
+++ b/airflow/models/dataset.py
@@ -222,7 +222,7 @@ class DatasetEvent(Base):
     __tablename__ = "dataset_event"
     __table_args__ = (
         ForeignKeyConstraint((dataset_id,), ["dataset.id"], name='datasetevent_dataset_fkey'),
-        Index('idx_dataset_id_created_at', dataset_id, created_at, unique=True),
+        Index('idx_dataset_id_created_at', dataset_id, created_at, mssql_clustered=True),
         {'sqlite_autoincrement': True},  # ensures PK values not reused
     )
 

--- a/airflow/models/dataset.py
+++ b/airflow/models/dataset.py
@@ -240,6 +240,13 @@ class DatasetEvent(Base):
 
     def __repr__(self):
         args = []
-        for attr in ['dataset_id', 'extra', 'source_dag_run_id']:
+        for attr in [
+            'dataset_id',
+            'extra',
+            'source_task_id',
+            'source_dag_id',
+            'source_run_id',
+            'source_map_index',
+        ]:
             args.append(f"{attr}={getattr(self, attr)!r}")
         return f"{self.__class__.__name__}({', '.join(args)})"

--- a/airflow/models/dataset.py
+++ b/airflow/models/dataset.py
@@ -17,7 +17,7 @@
 # under the License.
 from urllib.parse import urlparse
 
-from sqlalchemy import Column, ForeignKeyConstraint, Index, Integer, PrimaryKeyConstraint, String
+from sqlalchemy import Column, ForeignKeyConstraint, Index, Integer, PrimaryKeyConstraint, String, text
 from sqlalchemy.orm import relationship
 
 from airflow.models.base import ID_LEN, Base, StringID
@@ -197,5 +197,46 @@ class DatasetDagRunQueue(Base):
     def __repr__(self):
         args = []
         for attr in [x.name for x in self.__mapper__.primary_key]:
+            args.append(f"{attr}={getattr(self, attr)!r}")
+        return f"{self.__class__.__name__}({', '.join(args)})"
+
+
+class DatasetEvent(Base):
+    """
+    A table to store datasets events.
+
+    :param dataset_id: reference to Dataset record
+    :param extra: JSON field for arbitrary extra info
+    :param source_dag_run_id: key to dag run which produced the event
+    """
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    dataset_id = Column(Integer, nullable=False)
+    extra = Column(ExtendedJSON, nullable=True)
+    source_task_id = Column(StringID(), nullable=True)
+    source_dag_id = Column(StringID(), nullable=True)
+    source_run_id = Column(StringID(), nullable=True)
+    source_map_index = Column(Integer, nullable=True, server_default=text("-1"))
+    created_at = Column(UtcDateTime, default=timezone.utcnow, nullable=False)
+
+    __tablename__ = "dataset_event"
+    __table_args__ = (
+        ForeignKeyConstraint((dataset_id,), ["dataset.id"], name='datasetevent_dataset_fkey'),
+        Index('idx_dataset_id_created_at', dataset_id, created_at, unique=True),
+        {'sqlite_autoincrement': True},  # ensures PK values not reused
+    )
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.dataset_id == other.dataset_id and self.created_at == other.created_at
+        else:
+            return NotImplemented
+
+    def __hash__(self):
+        return hash((self.dataset_id, self.created_at))
+
+    def __repr__(self):
+        args = []
+        for attr in ['dataset_id', 'extra', 'source_dag_run_id']:
             args.append(f"{attr}={getattr(self, attr)!r}")
         return f"{self.__class__.__name__}({', '.join(args)})"

--- a/airflow/models/dataset.py
+++ b/airflow/models/dataset.py
@@ -207,7 +207,10 @@ class DatasetEvent(Base):
 
     :param dataset_id: reference to Dataset record
     :param extra: JSON field for arbitrary extra info
-    :param source_dag_run_id: key to dag run which produced the event
+    :param source_task_id: the task_id of the TI which updated the dataset
+    :param source_dag_id: the dag_id of the TI which updated the dataset
+    :param source_run_id: the run_id of the TI which updated the dataset
+    :param source_map_index: the map_index of the TI which updated the dataset
     """
 
     id = Column(Integer, primary_key=True, autoincrement=True)

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -95,7 +95,7 @@ from airflow.exceptions import (
     XComForMappingNotPushed,
 )
 from airflow.models.base import Base, StringID
-from airflow.models.dataset import DatasetDagRunQueue
+from airflow.models.dataset import DatasetDagRunQueue, DatasetEvent
 from airflow.models.log import Log
 from airflow.models.param import ParamsDict
 from airflow.models.taskfail import TaskFail
@@ -1513,10 +1513,10 @@ class TaskInstance(Base, LoggingMixin):
         if not test_mode:
             session.add(Log(self.state, self))
             session.merge(self)
-            self._create_dataset_dag_run_queue_records(session=session)
+            self._create_dataset_dag_run_queue_records(context=context, session=session)
             session.commit()
 
-    def _create_dataset_dag_run_queue_records(self, *, session):
+    def _create_dataset_dag_run_queue_records(self, *, context=None, session=NEW_SESSION):
         from airflow.models import Dataset
 
         for obj in getattr(self.task, '_outlets', []):
@@ -1529,7 +1529,18 @@ class TaskInstance(Base, LoggingMixin):
                 downstream_dag_ids = [x.dag_id for x in dataset.dag_references]
                 self.log.debug("downstream dag ids %s", downstream_dag_ids)
                 for dag_id in downstream_dag_ids:
+                    dataset_payload = context.get('dataset_payload')
                     session.merge(DatasetDagRunQueue(dataset_id=dataset.id, target_dag_id=dag_id))
+                    session.add(
+                        DatasetEvent(
+                            dataset_id=dataset.id,
+                            extra=dataset_payload,
+                            source_task_id=self.task_id,
+                            source_dag_id=self.dag_id,
+                            source_run_id=self.run_id,
+                            source_map_index=self.map_index,
+                        )
+                    )
 
     def _execute_task_with_callbacks(self, context, test_mode=False):
         """Prepare Task for Execution"""

--- a/airflow/models/taskinstance.py
+++ b/airflow/models/taskinstance.py
@@ -1528,19 +1528,19 @@ class TaskInstance(Base, LoggingMixin):
                     continue
                 downstream_dag_ids = [x.dag_id for x in dataset.dag_references]
                 self.log.debug("downstream dag ids %s", downstream_dag_ids)
-                for dag_id in downstream_dag_ids:
-                    dataset_payload = context.get('dataset_payload')
-                    session.merge(DatasetDagRunQueue(dataset_id=dataset.id, target_dag_id=dag_id))
-                    session.add(
-                        DatasetEvent(
-                            dataset_id=dataset.id,
-                            extra=dataset_payload,
-                            source_task_id=self.task_id,
-                            source_dag_id=self.dag_id,
-                            source_run_id=self.run_id,
-                            source_map_index=self.map_index,
-                        )
+                dataset_payload = context.get('dataset_payload')
+                session.add(
+                    DatasetEvent(
+                        dataset_id=dataset.id,
+                        extra=dataset_payload,
+                        source_task_id=self.task_id,
+                        source_dag_id=self.dag_id,
+                        source_run_id=self.run_id,
+                        source_map_index=self.map_index,
                     )
+                )
+                for dag_id in downstream_dag_ids:
+                    session.merge(DatasetDagRunQueue(dataset_id=dataset.id, target_dag_id=dag_id))
 
     def _execute_task_with_callbacks(self, context, test_mode=False):
         """Prepare Task for Execution"""


### PR DESCRIPTION
exploration adding dataset event [log] table which stores all events, even those which are ignored for purpose of dag run queue records (e.g. say the dataset has already been updated once and the dag run is still waiting on other datasets)

opens up some possibilities for more elaborate triggering behavior.  also, provides a way to scrutinize / surface / visualize all historical dataset events (the queue table's records are ephemeral, since it's a _queue_ 🤪 )

even before we have a chance to make enhancements beyond 2.4, i suspect it would be pretty easy for a user to write a long-running deferrable operator that would consume dataset events and  do things with them, e.g. implement more complex dag run triggering rules based on all the full event history.

one component i'm just starting to play with and think about is how to get information, to the consuming dag, about what actually happened in the dataset event -- e.g. was it appended to, or replaced, this kind of thing.  you can see in the change to `example_datasets.py` i'm using post_execute to insert some metadata in a dataset event payload.  


