### PR TITLE
Fix confusing log message in kubernetes executor

### DIFF
--- a/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
+++ b/airflow/providers/cncf/kubernetes/executors/kubernetes_executor.py
@@ -472,7 +472,7 @@ class KubernetesExecutor(BaseExecutor):
         if self.kube_config.delete_worker_pods:
             if state != TaskInstanceState.FAILED or self.kube_config.delete_worker_pods_on_failure:
                 self.kube_scheduler.delete_pod(pod_name=pod_name, namespace=namespace)
-                self.log.info("Deleted pod: %s in namespace %s", key, namespace)
+                self.log.info("Deleted pod associated with the TI %s. Pod name: %s. Namespace: %s", key, pod_name, namespace)
         else:
             self.kube_scheduler.patch_pod_executor_done(pod_name=pod_name, namespace=namespace)
             self.log.info("Patched pod %s in namespace %s to mark it as done", key, namespace)


### PR DESCRIPTION
The log message says that it's deleting a pod, but it only reports the namespace and TI key, but not the pod name.