### PR TITLE
Update Chart Publishing Workflow for Astro Branch Pattern

### DIFF
--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -20,7 +20,7 @@
 name: Publish Chart
 on:
   push:
-    branches: ['helm-chart/v[0-9]+-[0-9]+-[0-9]']
+    branches: ['helm-chart/v[0-9]+-[0-9]+-[0-9]+-astro']
 jobs:
   publish-chart:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Updates the GitHub Actions workflow branch pattern to support the new Astro helm chart release branches.

## Problem

The current workflow only triggers on branches matching `helm-chart/v[0-9]+-[0-9]+-[0-9]`, but our team is now using branches with the -astro suffix (e.g., `helm-chart/v1-15-0-astro`). This causes the chart publishing workflow to be skipped for these branches.

## Changes
 - Modified the on.push.branches pattern in the Chart Publishing workflow
 - This change specifically targets Astro helm chart release branches