### PR TITLE
Corrections

### DIFF
--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -332,6 +332,7 @@ spec:
           {{- if $containerLifecycleHooksLogGroomerSidecar }}
           lifecycle: {{- tpl (toYaml $containerLifecycleHooksLogGroomerSidecar) . | nindent 12 }}
           {{- end }}
+          {{- if hasKey .Values.workers.logGroomerSidecar "livenessProbe" }}
           livenessProbe:
             initialDelaySeconds: {{ .Values.workers.logGroomerSidecar.livenessProbe.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.workers.logGroomerSidecar.livenessProbe.timeoutSeconds }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -581,6 +581,14 @@ workers:
     failureThreshold: 5
     periodSeconds: 60
     command: ~
+  
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    timeoutSeconds: 20
+    failureThreshold: 5
+    periodSeconds: 60
+    command: ~
 
   # Update Strategy when worker is deployed as a StatefulSet
   updateStrategy: ~
@@ -880,6 +888,13 @@ scheduler:
   # If the scheduler stops heartbeating for 5 minutes (5*60s) kill the
   # scheduler and let Kubernetes restart it
   livenessProbe:
+    initialDelaySeconds: 10
+    timeoutSeconds: 20
+    failureThreshold: 5
+    periodSeconds: 60
+    command: ~
+  
+  readinessProbe:
     initialDelaySeconds: 10
     timeoutSeconds: 20
     failureThreshold: 5
@@ -1612,6 +1627,13 @@ triggerer:
   # If the triggerer stops heartbeating for 5 minutes (5*60s) kill the
   # triggerer and let Kubernetes restart it
   livenessProbe:
+    initialDelaySeconds: 10
+    timeoutSeconds: 20
+    failureThreshold: 5
+    periodSeconds: 60
+    command: ~
+  
+  readinessProbe:
     initialDelaySeconds: 10
     timeoutSeconds: 20
     failureThreshold: 5
@@ -2386,6 +2408,20 @@ redis:
 
     # Annotations to add to worker kubernetes service account.
     annotations: {}
+
+  livenessProbe:
+    initialDelaySeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 3
+    periodSeconds: 10
+    command: ~
+
+  readinessProbe:
+    initialDelaySeconds: 5
+    timeoutSeconds: 5
+    failureThreshold: 3
+    periodSeconds: 10
+    command: ~
 
   service:
     # service type, default: ClusterIP


### PR DESCRIPTION
## Description

Helm templating was failing with nil pointer evaluating interface errors when trying to access probe configurations that were missing from the default values.yaml file. The templates expected probe configurations for several components, but the values file was incomplete.

## Changes

Added missing probe configurations to the values.yaml file for the following components:

1. Workers

- Added missing readinessProbe configuration
- The workers section already had livenessProbe but was missing readinessProbe

2. Scheduler

- Added missing readinessProbe configuration
- The scheduler section had livenessProbe and startupProbe but was missing readinessProbe

3. Triggerer

 - Added missing readinessProbe configuration
 - The triggerer section already had livenessProbe but was missing readinessProbe

4. Redis
-  Added missing livenessProbe configuration
- Added missing readinessProbe configuration
- The redis section had no probe configurations at all


## Testing

- helm template now completes successfully without errors
![Screenshot 2025-05-28 at 6 13 19 PM](https://github.com/user-attachments/assets/b8426a59-e04e-4e03-bd6e-eb6bb722d349)

