### PR TITLE
Older behavior to be persisted rather than forcing new changes in values.yaml

### DIFF
--- a/chart/templates/redis/redis-statefulset.yaml
+++ b/chart/templates/redis/redis-statefulset.yaml
@@ -101,6 +101,7 @@ spec:
           ports:
             - name: redis-db
               containerPort: {{ .Values.ports.redisDB }}
+          {{ if .Values.redis.livenessProbe }}
           livenessProbe:
             initialDelaySeconds: {{ .Values.redis.livenessProbe.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.redis.livenessProbe.timeoutSeconds }}
@@ -115,6 +116,8 @@ spec:
                 - -c
                 - redis-cli -a $REDIS_PASSWORD ping
                 {{- end }}
+          {{- end }}
+          {{ if .Values.redis.readinessProbe }}
           readinessProbe:
             initialDelaySeconds: {{ .Values.redis.readinessProbe.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.redis.readinessProbe.timeoutSeconds }}
@@ -129,6 +132,7 @@ spec:
                 - -c
                 - redis-cli -a $REDIS_PASSWORD ping
                 {{- end }}
+          {{- end }}
           volumeMounts:
             - name: redis-db
               mountPath: /data

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -206,6 +206,7 @@ spec:
                 {{- else }}
                   {{- include "scheduler_liveness_check_command" . | indent 14 }}
                 {{- end }}
+          {{- if .Values.scheduler.readinessProbe }}
           readinessProbe:
             initialDelaySeconds: {{ .Values.scheduler.readinessProbe.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.scheduler.readinessProbe.timeoutSeconds }}
@@ -218,6 +219,7 @@ spec:
                 {{- else }}
                   {{- include "scheduler_readiness_check_command" . | indent 14 }}
                 {{- end }}
+          {{- end }}
           startupProbe:
             timeoutSeconds: {{ .Values.scheduler.startupProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.scheduler.startupProbe.failureThreshold }}
@@ -287,7 +289,7 @@ spec:
                 - "test -f /clean-logs && grep -q 'AIRFLOW__LOG_RETENTION_DAYS' /clean-logs"
               {{- end }}
           {{- end }}
-          
+
           # Add readinessProbe
           {{- if hasKey .Values.scheduler.logGroomerSidecar "readinessProbe" }}
           readinessProbe:

--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -216,6 +216,7 @@ spec:
                 {{- else }}
                   {{- include "triggerer_liveness_check_command" . | indent 14 }}
                 {{- end }}
+          {{- if .Values.triggerer.readinessProbe }}
           readinessProbe:
             initialDelaySeconds: {{ .Values.triggerer.readinessProbe.initialDelaySeconds }}
             timeoutSeconds: {{ .Values.triggerer.readinessProbe.timeoutSeconds }}
@@ -228,6 +229,7 @@ spec:
                 {{- else }}
                   {{- include "triggerer_readiness_check_command" . | indent 14 }}
                 {{- end }}
+          {{- end }}
         {{- /* Airflow version 2.6.0 is when triggerer logs serve introduced */ -}}
           {{- if semverCompare ">=2.6.0" .Values.airflowVersion }}
           ports:


### PR DESCRIPTION
The values.yaml being used before the upgrade should still work with the new probes being optional.