### PR TITLE
Add worker Readiness probes

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -583,12 +583,12 @@ workers:
     command: ~
   
   readinessProbe:
-    enabled: true
-    initialDelaySeconds: 10
-    timeoutSeconds: 20
-    failureThreshold: 5
-    periodSeconds: 60
-    command: ~
+    enabled: false
+    # initialDelaySeconds: 10
+    # timeoutSeconds: 20
+    # failureThreshold: 5
+    # periodSeconds: 60
+    # command: ~
 
   # Update Strategy when worker is deployed as a StatefulSet
   updateStrategy: ~
@@ -888,13 +888,6 @@ scheduler:
   # If the scheduler stops heartbeating for 5 minutes (5*60s) kill the
   # scheduler and let Kubernetes restart it
   livenessProbe:
-    initialDelaySeconds: 10
-    timeoutSeconds: 20
-    failureThreshold: 5
-    periodSeconds: 60
-    command: ~
-  
-  readinessProbe:
     initialDelaySeconds: 10
     timeoutSeconds: 20
     failureThreshold: 5
@@ -1627,13 +1620,6 @@ triggerer:
   # If the triggerer stops heartbeating for 5 minutes (5*60s) kill the
   # triggerer and let Kubernetes restart it
   livenessProbe:
-    initialDelaySeconds: 10
-    timeoutSeconds: 20
-    failureThreshold: 5
-    periodSeconds: 60
-    command: ~
-  
-  readinessProbe:
     initialDelaySeconds: 10
     timeoutSeconds: 20
     failureThreshold: 5
@@ -2408,20 +2394,6 @@ redis:
 
     # Annotations to add to worker kubernetes service account.
     annotations: {}
-
-  livenessProbe:
-    initialDelaySeconds: 30
-    timeoutSeconds: 5
-    failureThreshold: 3
-    periodSeconds: 10
-    command: ~
-
-  readinessProbe:
-    initialDelaySeconds: 5
-    timeoutSeconds: 5
-    failureThreshold: 3
-    periodSeconds: 10
-    command: ~
 
   service:
     # service type, default: ClusterIP


### PR DESCRIPTION
## Description

This PR intends to remove the probes which were not present by default. After just this addition we are able to template the helm charts without errors.

