### PR TITLE
Add enabled property to readiness probes for scheduler, triggerer, and pgbouncer components

### DIFF
--- a/chart/templates/pgbouncer/pgbouncer-deployment.yaml
+++ b/chart/templates/pgbouncer/pgbouncer-deployment.yaml
@@ -154,6 +154,7 @@ spec:
           {{- if $containerLifecycleHooks }}
           lifecycle: {{- tpl (toYaml $containerLifecycleHooks) . | nindent 12 }}
           {{- end }}
+          {{- if .Values.pgbouncer.metricsExporterSidecar.enabled }}
         - name: metrics-exporter
           resources: {{- toYaml .Values.pgbouncer.metricsExporterSidecar.resources | nindent 12 }}
           image: {{ template "pgbouncer_exporter_image" . }}
@@ -190,6 +191,7 @@ spec:
             timeoutSeconds: {{ .Values.pgbouncer.metricsExporterSidecar.readinessProbe.timeoutSeconds }}
           {{- if $containerLifecycleHooksMetricsExporter }}
           lifecycle: {{- tpl (toYaml $containerLifecycleHooksMetricsExporter) . | nindent 12 }}
+          {{- end }}
           {{- end }}
         {{- if .Values.pgbouncer.extraContainers }}
           {{- tpl (toYaml .Values.pgbouncer.extraContainers) . | nindent 8 }}

--- a/chart/templates/scheduler/scheduler-deployment.yaml
+++ b/chart/templates/scheduler/scheduler-deployment.yaml
@@ -273,39 +273,15 @@ spec:
           lifecycle: {{- tpl (toYaml $containerLifecycleHooksLogGroomerSidecar) . | nindent 12 }}
           {{- end }}
           # Add livenessProbe
-          {{- if hasKey .Values.scheduler.logGroomerSidecar "livenessProbe" }}
+          {{- if and (hasKey .Values.scheduler.logGroomerSidecar "livenessProbe") .Values.scheduler.logGroomerSidecar.livenessProbe.enabled }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.scheduler.logGroomerSidecar.livenessProbe.initialDelaySeconds }}
-            timeoutSeconds: {{ .Values.scheduler.logGroomerSidecar.livenessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.scheduler.logGroomerSidecar.livenessProbe.failureThreshold }}
-            periodSeconds: {{ .Values.scheduler.logGroomerSidecar.livenessProbe.periodSeconds }}
-            exec:
-              command:
-              {{- if hasKey .Values.scheduler.logGroomerSidecar.livenessProbe "command" }}
-                {{- toYaml .Values.scheduler.logGroomerSidecar.livenessProbe.command | nindent 16 }}
-              {{- else }}
-                - sh
-                - -c
-                - "test -f /clean-logs && grep -q 'AIRFLOW__LOG_RETENTION_DAYS' /clean-logs"
-              {{- end }}
+          {{- omit .Values.scheduler.logGroomerSidecar.livenessProbe "enabled" | toYaml | nindent 12 }}
           {{- end }}
 
           # Add readinessProbe
-          {{- if hasKey .Values.scheduler.logGroomerSidecar "readinessProbe" }}
+          {{- if and (hasKey .Values.scheduler.logGroomerSidecar "readinessProbe") .Values.scheduler.logGroomerSidecar.readinessProbe.enabled }}
           readinessProbe:
-            initialDelaySeconds: {{ .Values.scheduler.logGroomerSidecar.readinessProbe.initialDelaySeconds }}
-            timeoutSeconds: {{ .Values.scheduler.logGroomerSidecar.readinessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.scheduler.logGroomerSidecar.readinessProbe.failureThreshold }}
-            periodSeconds: {{ .Values.scheduler.logGroomerSidecar.readinessProbe.periodSeconds }}
-            exec:
-              command:
-              {{- if hasKey .Values.scheduler.logGroomerSidecar.readinessProbe "command" }}
-                {{- toYaml .Values.scheduler.logGroomerSidecar.readinessProbe.command | nindent 16 }}
-                {{- else }}
-                - sh
-                - -c
-                - "test -e /clean-logs"
-              {{- end }}
+          {{- omit .Values.scheduler.logGroomerSidecar.readinessProbe "enabled" | toYaml | nindent 12 }}
           {{- end }}
           {{- if .Values.scheduler.logGroomerSidecar.command }}
           command: {{ tpl (toYaml .Values.scheduler.logGroomerSidecar.command) . | nindent 12 }}

--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -204,31 +204,14 @@ spec:
             {{- include "custom_airflow_environment" . | indent 10 }}
             {{- include "standard_airflow_environment" . | indent 10 }}
             {{- include "container_extra_envs" (list . .Values.triggerer.env) | nindent 10 }}
+          {{- if and (hasKey .Values.triggerer.logGroomerSidecar "livenessProbe") .Values.triggerer.logGroomerSidecar.livenessProbe.enabled }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.triggerer.livenessProbe.initialDelaySeconds }}
-            timeoutSeconds: {{ .Values.triggerer.livenessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.triggerer.livenessProbe.failureThreshold }}
-            periodSeconds: {{ .Values.triggerer.livenessProbe.periodSeconds }}
-            exec:
-              command:
-                {{- if .Values.triggerer.livenessProbe.command }}
-                  {{- toYaml .Values.triggerer.livenessProbe.command | nindent 16 }}
-                {{- else }}
-                  {{- include "triggerer_liveness_check_command" . | indent 14 }}
-                {{- end }}
-          {{- if .Values.triggerer.readinessProbe }}
+          {{- omit .Values.triggerer.logGroomerSidecar.livenessProbe "enabled" | toYaml | nindent 12 }}
+          {{- end }}
+
+          {{- if and (hasKey .Values.triggerer.logGroomerSidecar "readinessProbe") .Values.triggerer.logGroomerSidecar.readinessProbe.enabled }}
           readinessProbe:
-            initialDelaySeconds: {{ .Values.triggerer.readinessProbe.initialDelaySeconds }}
-            timeoutSeconds: {{ .Values.triggerer.readinessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.triggerer.readinessProbe.failureThreshold }}
-            periodSeconds: {{ .Values.triggerer.readinessProbe.periodSeconds }}
-            exec:
-              command:
-                {{- if .Values.triggerer.readinessProbe.command }}
-                  {{- toYaml .Values.triggerer.readinessProbe.command | nindent 16 }}
-                {{- else }}
-                  {{- include "triggerer_readiness_check_command" . | indent 14 }}
-                {{- end }}
+          {{- omit .Values.triggerer.logGroomerSidecar.readinessProbe "enabled" | toYaml | nindent 12 }}
           {{- end }}
         {{- /* Airflow version 2.6.0 is when triggerer logs serve introduced */ -}}
           {{- if semverCompare ">=2.6.0" .Values.airflowVersion }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -12678,6 +12678,11 @@
                     "default": {},
                     "additionalProperties": false,
                     "properties": {
+                        "enabled": {
+                        "description": "Enable liveness probe for log groomer sidecar.",
+                        "type": "boolean",
+                        "default": false
+                    },
                         "exec": {
                             "description": "Exec specifies the action to take.",
                             "type": "object",
@@ -12719,6 +12724,11 @@
                     "default": {},
                     "additionalProperties": false,
                     "properties": {
+                        "enabled": {
+                        "description": "Enable readiness probe for log groomer sidecar.",
+                        "type": "boolean",
+                        "default": false
+                        },
                         "exec": {
                             "description": "Exec specifies the action to take.",
                             "type": "object",

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -3181,6 +3181,11 @@
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
+                        "enabled": {
+                            "description": "Enable readiness probe",
+                            "type": "boolean",
+                            "default": true
+                        },
                         "initialDelaySeconds": {
                             "description": "Number of seconds after the container has started before liveness probes are initiated.",
                             "type": "integer",
@@ -3222,6 +3227,11 @@
                     "default": {},
                     "additionalProperties": false,
                     "properties": {
+                        "enabled": {
+                            "description": "Enable readiness probe",
+                            "type": "boolean",
+                            "default": true
+                        },
                         "initialDelaySeconds": {
                             "description": "Number of seconds after the container has started before readiness probes are initiated.",
                             "type": "integer",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1041,6 +1041,30 @@ scheduler:
     # container level lifecycle hooks
     containerLifecycleHooks: {}
     env: []
+    #  Liveness probe configuration for log groomer sidecar
+    livenessProbe:
+      enabled: false
+      # initialDelaySeconds: 10
+      # timeoutSeconds: 20
+      # failureThreshold: 5
+      # periodSeconds: 60
+      # exec:
+      #   command:
+      #     - sh
+      #     - -c
+      #     - "test -f /clean-logs && grep -q 'AIRFLOW__LOG_RETENTION_DAYS' /clean-logs"
+    
+    readinessProbe:
+      enabled: false
+      # initialDelaySeconds: 10
+      # timeoutSeconds: 20
+      # failureThreshold: 5
+      # periodSeconds: 60
+      # exec:
+      #   command:
+      #     - sh
+      #     - -c
+      #     - "test -f /clean-logs && grep -q 'AIRFLOW__LOG_RETENTION_DAYS' /clean-logs"
 
   waitForMigrations:
     # Whether to create init container to wait for db migrations

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2358,6 +2358,7 @@ pgbouncer:
         command: ["/bin/sh", "-c", "killall -INT pgbouncer && sleep 120"]
 
   metricsExporterSidecar:
+    enabled: true
     resources: {}
     #  limits:
     #   cpu: 100m

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1644,12 +1644,20 @@ triggerer:
   # If the triggerer stops heartbeating for 5 minutes (5*60s) kill the
   # triggerer and let Kubernetes restart it
   livenessProbe:
+    enabled: false
     initialDelaySeconds: 10
     timeoutSeconds: 20
     failureThreshold: 5
     periodSeconds: 60
     command: ~
 
+  readinessProbe:
+    enabled: false
+    initialDelaySeconds: 10
+    timeoutSeconds: 20
+    failureThreshold: 5
+    periodSeconds: 60
+    command: ~
   # Create ServiceAccount
   serviceAccount:
     # default value is true


### PR DESCRIPTION
## Summary

This PR adds the ability to conditionally enable/disable readiness probes for the scheduler, triggerer, and pgbouncer components by introducing an enabled boolean property to their readiness probe configurations.

## Changes

### Templates Updated:

 - **scheduler-deployment.yaml**: Added conditional check {{- if and (hasKey .Values.scheduler.logGroomerSidecar "readinessProbe") .Values.scheduler.logGroomerSidecar.readinessProbe.enabled }} to wrap readiness probe configuration

- **triggerer-deployment.yaml**: Added conditional checks for both liveness and readiness probes using .Values.triggerer.logGroomerSidecar.livenessProbe.enabled and .Values.triggerer.logGroomerSidecar.readinessProbe.enabled

- **pgbouncer-deployment.yaml:** Added conditional check {{- if .Values.pgbouncer.metricsExporterSidecar.enabled }} for metrics exporter sidecar

### Schema Updates (values.schema.json):

- Added enabled property to readiness probe configurations for:

- Scheduler log groomer sidecar
- Triggerer log groomer sidecar
