### PR TITLE
Adding a TTL to the Cleanup job

### DIFF
--- a/chart/templates/cleanup/cleanup-cronjob.yaml
+++ b/chart/templates/cleanup/cleanup-cronjob.yaml
@@ -56,6 +56,7 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 1
+      activeDeadlineSeconds: {{ .Values.cleanup.activeDeadlineSeconds }}
       template:
         metadata:
           labels:

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -8694,6 +8694,15 @@
                     ],
                     "default": null,
                     "x-docsSection": null
+                },
+                "activeDeadlineSeconds": {
+                    "description": "Specify a TTL for all Pods launched by the cleanup Job",
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "default": 180,
+                    "x-docsSection": null
                 }
             }
         },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -2791,6 +2791,9 @@ cleanup:
   failedJobsHistoryLimit: ~
   successfulJobsHistoryLimit: ~
 
+  # Specify a TTL for all Pods launched by the cleanup Job
+  activeDeadlineSeconds: 180
+
 # Configuration for postgresql subchart
 # Not recommended for production
 postgresql:


### PR DESCRIPTION
The Cleanup job runs periodically to delete Completed Pods from KPO or K8s Exec usage. It's possible for the cleanup Pod to be in a healthy state according to K8s but still not doing any cleanup. If the Pod itself is healthy then the Job won't restart it and the Pod just sits forever since there is no TTL.

This PR adds an `activeDeadlineSeconds` field to the Job which prevents this from happening. I've defaulted to 180 seconds.
