### PR TITLE
Add Configurable Health Probes for Triggerer Log Groomer Sidecar

### DIFF
--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -231,38 +231,18 @@ spec:
           {{- if $containerLifecycleHooksLogGroomerSidecar }}
           lifecycle: {{- tpl (toYaml $containerLifecycleHooksLogGroomerSidecar) . | nindent 12 }}
           {{- end }}
-          {{- if hasKey .Values.triggerer.logGroomerSidecar "livenessProbe" }}
+          # Add livenessProbe
+          {{- if and .Values.triggerer.logGroomerSidecar.livenessProbe .Values.triggerer.logGroomerSidecar.livenessProbe.enabled }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.triggerer.logGroomerSidecar.livenessProbe.initialDelaySeconds }}
-            timeoutSeconds: {{ .Values.triggerer.logGroomerSidecar.livenessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.triggerer.logGroomerSidecar.livenessProbe.failureThreshold }}
-            periodSeconds: {{ .Values.triggerer.logGroomerSidecar.livenessProbe.periodSeconds }}
-            exec:
-              command:
-              {{- if hasKey .Values.triggerer.logGroomerSidecar.livenessProbe "command" }}
-                {{- toYaml .Values.triggerer.logGroomerSidecar.livenessProbe.command | nindent 16 }}
-              {{- else }}
-                - sh
-                - -c
-                - "test -f /clean-logs && grep -q 'AIRFLOW__LOG_RETENTION_DAYS' /clean-logs"
-              {{- end }}
+          {{- omit .Values.triggerer.logGroomerSidecar.livenessProbe "enabled" | toYaml | nindent 12 }}
           {{- end }}
-          {{- if hasKey .Values.triggerer.logGroomerSidecar "readinessProbe" }}
+
+          # Add readinessProbe
+          {{- if and .Values.triggerer.logGroomerSidecar.readinessProbe .Values.triggerer.logGroomerSidecar.readinessProbe.enabled }}
           readinessProbe:
-            initialDelaySeconds: {{ .Values.triggerer.logGroomerSidecar.readinessProbe.initialDelaySeconds }}
-            timeoutSeconds: {{ .Values.triggerer.logGroomerSidecar.readinessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.triggerer.logGroomerSidecar.readinessProbe.failureThreshold }}
-            periodSeconds: {{ .Values.triggerer.logGroomerSidecar.readinessProbe.periodSeconds }}
-            exec:
-              command:
-              {{- if hasKey .Values.triggerer.logGroomerSidecar.readinessProbe "command" }}
-                {{- toYaml .Values.triggerer.logGroomerSidecar.readinessProbe.command | nindent 16 }}
-              {{- else }}
-                - sh
-                - -c
-                - "test -e /clean-logs"
-              {{- end }}
+          {{- omit .Values.triggerer.logGroomerSidecar.readinessProbe "enabled" | toYaml | nindent 12 }}
           {{- end }}
+
           {{- if .Values.triggerer.logGroomerSidecar.command }}
           command: {{ tpl (toYaml .Values.triggerer.logGroomerSidecar.command) . | nindent 12 }}
           {{- end }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -3182,7 +3182,7 @@
                     "additionalProperties": false,
                     "properties": {
                         "enabled": {
-                            "description": "Enable readiness probe",
+                            "description": "Enable Liveness probe",
                             "type": "boolean",
                             "default": true
                         },

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1790,6 +1790,28 @@ triggerer:
     # Detailed default security context for logGroomerSidecar for container level
     securityContexts:
       container: {}
+    livenessProbe:
+      enabled: false
+      # initialDelaySeconds: 10
+      # timeoutSeconds: 20
+      # failureThreshold: 5
+      # periodSeconds: 60
+      # exec:
+      #   command:
+      #     - sh
+      #     - -c
+      #     - "test -f /clean-logs && grep -q 'AIRFLOW__LOG_RETENTION_DAYS' /clean-logs"
+    readinessProbe: 
+      enabled: false
+      # initialDelaySeconds: 10
+      # timeoutSeconds: 20
+      # failureThreshold: 5
+      # periodSeconds: 60
+      # exec:
+      #   command:
+      #     - sh
+      #     - -c
+      #     - "test -f /clean-logs && grep -q 'AIRFLOW__LOG_RETENTION_DAYS' /clean-logs"
 
     # container level lifecycle hooks
     containerLifecycleHooks: {}


### PR DESCRIPTION
## Summary
This PR adds support for configurable liveness and readiness probes for the triggerer log groomer sidecar container, providing better monitoring and health checks for log cleanup operations as a dictionary.

## Changes Made

- Added livenessProbe and readinessProbe configuration blocks to triggerer.logGroomerSidecar in values.yaml
- Both probes are disabled by default (enabled: false) to maintain backward compatibility
- Implemented conditional templating in triggerer-deployment.yaml to include probes only when enabled

## Configuration Example
```
triggerer:
  logGroomerSidecar:
    livenessProbe:
      enabled: true
      initialDelaySeconds: 10
      timeoutSeconds: 20
      failureThreshold: 5
      periodSeconds: 60
      command: "test -f /clean-logs && grep -q 'AIRFLOW_LOG_RETENTION_DAYS' /clean-logs"
    readinessProbe:
      enabled: true
      # ... similar configuration
```

## Testing

- Verified template rendering with probes enabled/disabled
![Screenshot 2025-05-31 at 11 27 28 AM](https://github.com/user-attachments/assets/71fcaba8-c21c-418b-b474-d034dadb0982)

- Tested Helm chart deployment with various probe configurations
![Screenshot 2025-05-31 at 11 28 02 AM](https://github.com/user-attachments/assets/a36491a8-51c6-4df7-8a73-c98d59a4e654)
