### PR TITLE
Revert Health Probe Configuration for Triggerer 

### DIFF
--- a/chart/templates/triggerer/triggerer-deployment.yaml
+++ b/chart/templates/triggerer/triggerer-deployment.yaml
@@ -204,14 +204,33 @@ spec:
             {{- include "custom_airflow_environment" . | indent 10 }}
             {{- include "standard_airflow_environment" . | indent 10 }}
             {{- include "container_extra_envs" (list . .Values.triggerer.env) | nindent 10 }}
-          {{- if and .Values.triggerer.livenessProbe .Values.triggerer.livenessProbe.enabled }}
-          livenessProbe:
-          {{- omit .Values.triggerer.livenessProbe "enabled" | toYaml | nindent 12 }}
-          {{- end }}
 
-          {{- if and .Values.triggerer.readinessProbe .Values.triggerer.readinessProbe.enabled }}
+          livenessProbe:
+              initialDelaySeconds: {{ .Values.triggerer.livenessProbe.initialDelaySeconds }}
+              timeoutSeconds: {{ .Values.triggerer.livenessProbe.timeoutSeconds }}
+              failureThreshold: {{ .Values.triggerer.livenessProbe.failureThreshold }}
+              periodSeconds: {{ .Values.triggerer.livenessProbe.periodSeconds }}
+              exec:
+                command:
+                  {{- if .Values.triggerer.livenessProbe.command }}
+                    {{- toYaml .Values.triggerer.livenessProbe.command | nindent 16 }}
+                  {{- else }}
+                    {{- include "triggerer_liveness_check_command" . | indent 14 }}
+                  {{- end }}
+
+          {{- if .Values.triggerer.readinessProbe }}
           readinessProbe:
-          {{- omit .Values.triggerer.readinessProbe "enabled" | toYaml | nindent 12 }}
+              initialDelaySeconds: {{ .Values.triggerer.readinessProbe.initialDelaySeconds }}
+              timeoutSeconds: {{ .Values.triggerer.readinessProbe.timeoutSeconds }}
+              failureThreshold: {{ .Values.triggerer.readinessProbe.failureThreshold }}
+              periodSeconds: {{ .Values.triggerer.readinessProbe.periodSeconds }}
+              exec:
+                command:
+                  {{- if .Values.triggerer.readinessProbe.command }}
+                    {{- toYaml .Values.triggerer.readinessProbe.command | nindent 16 }}
+                  {{- else }}
+                    {{- include "triggerer_readiness_check_command" . | indent 14 }}
+                  {{- end }}
           {{- end }}
         {{- /* Airflow version 2.6.0 is when triggerer logs serve introduced */ -}}
           {{- if semverCompare ">=2.6.0" .Values.airflowVersion }}

--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -3181,11 +3181,6 @@
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
-                        "enabled": {
-                            "description": "Enable Liveness probe",
-                            "type": "boolean",
-                            "default": true
-                        },
                         "initialDelaySeconds": {
                             "description": "Number of seconds after the container has started before liveness probes are initiated.",
                             "type": "integer",
@@ -3227,11 +3222,6 @@
                     "default": {},
                     "additionalProperties": false,
                     "properties": {
-                        "enabled": {
-                            "description": "Enable readiness probe",
-                            "type": "boolean",
-                            "default": true
-                        },
                         "initialDelaySeconds": {
                             "description": "Number of seconds after the container has started before readiness probes are initiated.",
                             "type": "integer",

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1644,20 +1644,12 @@ triggerer:
   # If the triggerer stops heartbeating for 5 minutes (5*60s) kill the
   # triggerer and let Kubernetes restart it
   livenessProbe:
-    enabled: false
     initialDelaySeconds: 10
     timeoutSeconds: 20
     failureThreshold: 5
     periodSeconds: 60
     command: ~
 
-  readinessProbe:
-    enabled: false
-    initialDelaySeconds: 10
-    timeoutSeconds: 20
-    failureThreshold: 5
-    periodSeconds: 60
-    command: ~
   # Create ServiceAccount
   serviceAccount:
     # default value is true


### PR DESCRIPTION
## Description

This PR reverts the previously added liveness and readiness probe configuration for the triggerer  container. The health probe functionality has been removed from both the Helm template and values configuration.

## Changes Reverted


- Removed livenessProbe and readinessProbe enable configuration blocks from triggerer in values.yaml
- Removed conditional templating for health probes in triggerer-deployment.yaml
- Removed probe configuration options including:
      - enabled flag

## Reason for Revert

- To maintain Helm chart consistency across the codebase. 
- The scheduler container follows the same pattern of not having enable functionality for probes.

## Issue
https://github.com/astronomer/issues/issues/7291

## Testing
- Helm template rendering verified without probe configurations.
![Screenshot 2025-05-31 at 12 25 45 PM](https://github.com/user-attachments/assets/14974086-fc30-4093-8326-af81f5defcdf)

- Chart deployment tested to ensure no template errors
