### PR TITLE
Add Template Support for Service Account Names

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -598,20 +598,19 @@ server_tls_key_file = /etc/pgbouncer/server.key
 
 {{/* Create the name of the webserver service account to use */}}
 {{- define "webserver.serviceAccountName" -}}
-  {{- if .Values.webserver.serviceAccount.create }}
-    {{- default (printf "%s-webserver" (include "airflow.serviceAccountName" .)) .Values.webserver.serviceAccount.name }}
-  {{- else }}
-    {{- default "default" .Values.webserver.serviceAccount.name }}
-  {{- end }}
+ {{- if .Values.webserver.serviceAccount.create }}
+   {{ default (printf "%s-webserver" (include "airflow.serviceAccountName" .)) .Values.webserver.serviceAccount.name }}
+ {{- else }}
+   {{- tpl .Values.webserver.serviceAccount.name . }}
+ {{- end }}
 {{- end }}
-
 
 {{/* Create the name of the RPC server service account to use */}}
 {{- define "rpcServer.serviceAccountName" -}}
   {{- if .Values._rpcServer.serviceAccount.create }}
-    {{- default (printf "%s-rpc-server" (include "airflow.serviceAccountName" .)) .Values._rpcServer.serviceAccount.name }}
+    {{ default (printf "%s-rpc-server" (include "airflow.serviceAccountName" .)) .Values._rpcServer.serviceAccount.name }}
   {{- else }}
-    {{- default "default" .Values._rpcServer.serviceAccount.name }}
+    {{- tpl .Values._rpcServer.serviceAccount.name }}
   {{- end }}
 {{- end }}
 
@@ -620,7 +619,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.redis.serviceAccount.create }}
     {{- default (printf "%s-redis" (include "airflow.serviceAccountName" .)) .Values.redis.serviceAccount.name }}
   {{- else }}
-    {{- default "default" .Values.redis.serviceAccount.name }}
+    {{- tpl .Values.redis.serviceAccount.name }}
   {{- end }}
 {{- end }}
 
@@ -629,7 +628,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.flower.serviceAccount.create }}
     {{- default (printf "%s-flower" (include "airflow.serviceAccountName" .)) .Values.flower.serviceAccount.name }}
   {{- else }}
-    {{- default "default" .Values.flower.serviceAccount.name }}
+    {{- tpl .Values.flower.serviceAccount.name }}
   {{- end }}
 {{- end }}
 
@@ -638,7 +637,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.scheduler.serviceAccount.create }}
     {{- default (printf "%s-scheduler" (include "airflow.serviceAccountName" .)) .Values.scheduler.serviceAccount.name }}
   {{- else }}
-    {{- default "default" .Values.scheduler.serviceAccount.name }}
+    {{- tpl .Values.scheduler.serviceAccount.name }}
   {{- end }}
 {{- end }}
 
@@ -647,7 +646,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.statsd.serviceAccount.create }}
     {{- default (printf "%s-statsd" (include "airflow.serviceAccountName" .)) .Values.statsd.serviceAccount.name }}
   {{- else }}
-    {{- default "default" .Values.statsd.serviceAccount.name }}
+    {{- tpl .Values.statsd.serviceAccount.name }}
   {{- end }}
 {{- end }}
 
@@ -656,7 +655,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.createUserJob.serviceAccount.create }}
     {{- default (printf "%s-create-user-job" (include "airflow.serviceAccountName" .)) .Values.createUserJob.serviceAccount.name }}
   {{- else }}
-    {{- default "default" .Values.createUserJob.serviceAccount.name }}
+    {{- tpl .Values.createUserJob.serviceAccount.name }}
   {{- end }}
 {{- end }}
 
@@ -665,7 +664,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.migrateDatabaseJob.serviceAccount.create }}
     {{- default (printf "%s-migrate-database-job" (include "airflow.serviceAccountName" .)) .Values.migrateDatabaseJob.serviceAccount.name }}
   {{- else }}
-    {{- default "default" .Values.migrateDatabaseJob.serviceAccount.name }}
+    {{- tpl .Values.migrateDatabaseJob.serviceAccount.name }}
   {{- end }}
 {{- end }}
 
@@ -674,7 +673,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.workers.serviceAccount.create }}
     {{- default (printf "%s-worker" (include "airflow.serviceAccountName" .)) .Values.workers.serviceAccount.name }}
   {{- else }}
-    {{- default "default" .Values.workers.serviceAccount.name }}
+    {{- tpl .Values.workers.serviceAccount.name }}
   {{- end }}
 {{- end }}
 
@@ -683,7 +682,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.triggerer.serviceAccount.create }}
     {{- default (printf "%s-triggerer" (include "airflow.serviceAccountName" .)) .Values.triggerer.serviceAccount.name }}
   {{- else }}
-    {{- default "default" .Values.triggerer.serviceAccount.name }}
+    {{- tpl .Values.triggerer.serviceAccount.name }}
   {{- end }}
 {{- end }}
 
@@ -692,7 +691,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.dagProcessor.serviceAccount.create }}
     {{- default (printf "%s-dag-processor" (include "airflow.serviceAccountName" .)) .Values.dagProcessor.serviceAccount.name }}
   {{- else }}
-    {{- default "default" .Values.dagProcessor.serviceAccount.name }}
+    {{- tpl .Values.dagProcessor.serviceAccount.name }}
   {{- end }}
 {{- end }}
 
@@ -701,7 +700,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.pgbouncer.serviceAccount.create }}
     {{- default (printf "%s-pgbouncer" (include "airflow.serviceAccountName" .)) .Values.pgbouncer.serviceAccount.name }}
   {{- else }}
-    {{- default "default" .Values.pgbouncer.serviceAccount.name }}
+    {{- tpl .Values.pgbouncer.serviceAccount.name }}
   {{- end }}
 {{- end }}
 
@@ -710,7 +709,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.cleanup.serviceAccount.create }}
     {{- default (printf "%s-cleanup" (include "airflow.serviceAccountName" .)) .Values.cleanup.serviceAccount.name }}
   {{- else }}
-    {{- default "default" .Values.cleanup.serviceAccount.name }}
+    {{- tpl .Values.cleanup.serviceAccount.name }}
   {{- end }}
 {{- end }}
 

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -610,7 +610,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values._rpcServer.serviceAccount.create }}
     {{ default (printf "%s-rpc-server" (include "airflow.serviceAccountName" .)) .Values._rpcServer.serviceAccount.name }}
   {{- else }}
-    {{- tpl .Values._rpcServer.serviceAccount.name }}
+    {{- tpl .Values._rpcServer.serviceAccount.name . }}
   {{- end }}
 {{- end }}
 
@@ -619,7 +619,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.redis.serviceAccount.create }}
     {{- default (printf "%s-redis" (include "airflow.serviceAccountName" .)) .Values.redis.serviceAccount.name }}
   {{- else }}
-    {{- tpl .Values.redis.serviceAccount.name }}
+    {{- tpl .Values.redis.serviceAccount.name . }}
   {{- end }}
 {{- end }}
 
@@ -628,7 +628,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.flower.serviceAccount.create }}
     {{- default (printf "%s-flower" (include "airflow.serviceAccountName" .)) .Values.flower.serviceAccount.name }}
   {{- else }}
-    {{- tpl .Values.flower.serviceAccount.name }}
+    {{- tpl .Values.flower.serviceAccount.name . }}
   {{- end }}
 {{- end }}
 
@@ -637,7 +637,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.scheduler.serviceAccount.create }}
     {{- default (printf "%s-scheduler" (include "airflow.serviceAccountName" .)) .Values.scheduler.serviceAccount.name }}
   {{- else }}
-    {{- tpl .Values.scheduler.serviceAccount.name }}
+    {{- tpl .Values.scheduler.serviceAccount.name . }}
   {{- end }}
 {{- end }}
 
@@ -646,7 +646,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.statsd.serviceAccount.create }}
     {{- default (printf "%s-statsd" (include "airflow.serviceAccountName" .)) .Values.statsd.serviceAccount.name }}
   {{- else }}
-    {{- tpl .Values.statsd.serviceAccount.name }}
+    {{- tpl .Values.statsd.serviceAccount.name . }}
   {{- end }}
 {{- end }}
 
@@ -655,7 +655,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.createUserJob.serviceAccount.create }}
     {{- default (printf "%s-create-user-job" (include "airflow.serviceAccountName" .)) .Values.createUserJob.serviceAccount.name }}
   {{- else }}
-    {{- tpl .Values.createUserJob.serviceAccount.name }}
+    {{- tpl .Values.createUserJob.serviceAccount.name . }}
   {{- end }}
 {{- end }}
 
@@ -664,7 +664,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.migrateDatabaseJob.serviceAccount.create }}
     {{- default (printf "%s-migrate-database-job" (include "airflow.serviceAccountName" .)) .Values.migrateDatabaseJob.serviceAccount.name }}
   {{- else }}
-    {{- tpl .Values.migrateDatabaseJob.serviceAccount.name }}
+    {{- tpl .Values.migrateDatabaseJob.serviceAccount.name . }}
   {{- end }}
 {{- end }}
 
@@ -673,7 +673,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.workers.serviceAccount.create }}
     {{- default (printf "%s-worker" (include "airflow.serviceAccountName" .)) .Values.workers.serviceAccount.name }}
   {{- else }}
-    {{- tpl .Values.workers.serviceAccount.name }}
+    {{- tpl .Values.workers.serviceAccount.name . }}
   {{- end }}
 {{- end }}
 
@@ -682,7 +682,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.triggerer.serviceAccount.create }}
     {{- default (printf "%s-triggerer" (include "airflow.serviceAccountName" .)) .Values.triggerer.serviceAccount.name }}
   {{- else }}
-    {{- tpl .Values.triggerer.serviceAccount.name }}
+    {{- tpl .Values.triggerer.serviceAccount.name . }}
   {{- end }}
 {{- end }}
 
@@ -691,7 +691,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.dagProcessor.serviceAccount.create }}
     {{- default (printf "%s-dag-processor" (include "airflow.serviceAccountName" .)) .Values.dagProcessor.serviceAccount.name }}
   {{- else }}
-    {{- tpl .Values.dagProcessor.serviceAccount.name }}
+    {{- tpl .Values.dagProcessor.serviceAccount.name . }}
   {{- end }}
 {{- end }}
 
@@ -700,7 +700,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.pgbouncer.serviceAccount.create }}
     {{- default (printf "%s-pgbouncer" (include "airflow.serviceAccountName" .)) .Values.pgbouncer.serviceAccount.name }}
   {{- else }}
-    {{- tpl .Values.pgbouncer.serviceAccount.name }}
+    {{- tpl .Values.pgbouncer.serviceAccount.name . }}
   {{- end }}
 {{- end }}
 
@@ -709,7 +709,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.cleanup.serviceAccount.create }}
     {{- default (printf "%s-cleanup" (include "airflow.serviceAccountName" .)) .Values.cleanup.serviceAccount.name }}
   {{- else }}
-    {{- tpl .Values.cleanup.serviceAccount.name }}
+    {{- tpl .Values.cleanup.serviceAccount.name . }}
   {{- end }}
 {{- end }}
 

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -601,7 +601,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
  {{- if .Values.webserver.serviceAccount.create }}
    {{ default (printf "%s-webserver" (include "airflow.serviceAccountName" .)) .Values.webserver.serviceAccount.name }}
  {{- else }}
-   {{tpl (default "default" .Values.webserver.serviceAccount.name) . }}
+   {{ tpl (default "default" .Values.webserver.serviceAccount.name) . }}
  {{- end }}
 {{- end }}
 
@@ -610,7 +610,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values._rpcServer.serviceAccount.create }}
     {{ default (printf "%s-rpc-server" (include "airflow.serviceAccountName" .)) .Values._rpcServer.serviceAccount.name }}
   {{- else }}
-    {{tpl (default "default" .Values._rpcServer.serviceAccount.name) . }}
+    {{ tpl (default "default" .Values._rpcServer.serviceAccount.name) . }}
   {{- end }}
 {{- end }}
 
@@ -619,7 +619,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.redis.serviceAccount.create }}
     {{- default (printf "%s-redis" (include "airflow.serviceAccountName" .)) .Values.redis.serviceAccount.name }}
   {{- else }}
-    {{tpl (default "default" .Values.redis.serviceAccount.name) . }}
+    {{ tpl (default "default" .Values.redis.serviceAccount.name) . }}
   {{- end }}
 {{- end }}
 
@@ -628,7 +628,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.flower.serviceAccount.create }}
     {{- default (printf "%s-flower" (include "airflow.serviceAccountName" .)) .Values.flower.serviceAccount.name }}
   {{- else }}
-    {{tpl (default "default" .Values.flower.serviceAccount.name) . }}
+    {{ tpl (default "default" .Values.flower.serviceAccount.name) . }}
   {{- end }}
 {{- end }}
 
@@ -637,7 +637,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.scheduler.serviceAccount.create }}
     {{- default (printf "%s-scheduler" (include "airflow.serviceAccountName" .)) .Values.scheduler.serviceAccount.name }}
   {{- else }}
-    {{tpl (default "default" .Values.scheduler.serviceAccount.name) . }}
+    {{ tpl (default "default" .Values.scheduler.serviceAccount.name) . }}
   {{- end }}
 {{- end }}
 
@@ -646,7 +646,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.statsd.serviceAccount.create }}
     {{- default (printf "%s-statsd" (include "airflow.serviceAccountName" .)) .Values.statsd.serviceAccount.name }}
   {{- else }}
-    {{tpl (default "default" .Values.statsd.serviceAccount.name) . }}
+    {{ tpl (default "default" .Values.statsd.serviceAccount.name) . }}
   {{- end }}
 {{- end }}
 
@@ -655,7 +655,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.createUserJob.serviceAccount.create }}
     {{- default (printf "%s-create-user-job" (include "airflow.serviceAccountName" .)) .Values.createUserJob.serviceAccount.name }}
   {{- else }}
-    {{tpl (default "default" .Values.createUserJob.serviceAccount.name) . }}
+    {{ tpl (default "default" .Values.createUserJob.serviceAccount.name) . }}
   {{- end }}
 {{- end }}
 
@@ -664,7 +664,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.migrateDatabaseJob.serviceAccount.create }}
     {{- default (printf "%s-migrate-database-job" (include "airflow.serviceAccountName" .)) .Values.migrateDatabaseJob.serviceAccount.name }}
   {{- else }}
-    {{tpl (default "default" .Values.migrateDatabaseJob.serviceAccount.name) . }}
+    {{ tpl (default "default" .Values.migrateDatabaseJob.serviceAccount.name) . }}
   {{- end }}
 {{- end }}
 
@@ -673,7 +673,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.workers.serviceAccount.create }}
     {{- default (printf "%s-worker" (include "airflow.serviceAccountName" .)) .Values.workers.serviceAccount.name }}
   {{- else }}
-    {{tpl (default "default" .Values.workers.serviceAccount.name) . }}
+    {{ tpl (default "default" .Values.workers.serviceAccount.name) . }}
   {{- end }}
 {{- end }}
 
@@ -682,7 +682,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.triggerer.serviceAccount.create }}
     {{- default (printf "%s-triggerer" (include "airflow.serviceAccountName" .)) .Values.triggerer.serviceAccount.name }}
   {{- else }}
-    {{tpl (default "default" .Values.triggerer.serviceAccount.name) . }}
+    {{ tpl (default "default" .Values.triggerer.serviceAccount.name) . }}
   {{- end }}
 {{- end }}
 
@@ -691,7 +691,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.dagProcessor.serviceAccount.create }}
     {{- default (printf "%s-dag-processor" (include "airflow.serviceAccountName" .)) .Values.dagProcessor.serviceAccount.name }}
   {{- else }}
-    {{tpl (default "default" .Values.dagProcessor.serviceAccount.name) . }}
+    {{ tpl (default "default" .Values.dagProcessor.serviceAccount.name) . }}
   {{- end }}
 {{- end }}
 
@@ -700,7 +700,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.pgbouncer.serviceAccount.create }}
     {{- default (printf "%s-pgbouncer" (include "airflow.serviceAccountName" .)) .Values.pgbouncer.serviceAccount.name }}
   {{- else }}
-    {{tpl (default "default" .Values.pgbouncer.serviceAccount.name) . }}
+    {{ tpl (default "default" .Values.pgbouncer.serviceAccount.name) . }}
   {{- end }}
 {{- end }}
 
@@ -709,7 +709,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.cleanup.serviceAccount.create }}
     {{- default (printf "%s-cleanup" (include "airflow.serviceAccountName" .)) .Values.cleanup.serviceAccount.name }}
   {{- else }}
-    {{tpl (default "default" .Values.cleanup.serviceAccount.name) . }}
+    {{ tpl (default "default" .Values.cleanup.serviceAccount.name) . }}
   {{- end }}
 {{- end }}
 

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -599,18 +599,18 @@ server_tls_key_file = /etc/pgbouncer/server.key
 {{/* Create the name of the webserver service account to use */}}
 {{- define "webserver.serviceAccountName" -}}
  {{- if .Values.webserver.serviceAccount.create }}
-   {{ default (printf "%s-webserver" (include "airflow.serviceAccountName" .)) .Values.webserver.serviceAccount.name }}
+   {{- default (printf "%s-webserver" (include "airflow.serviceAccountName" .)) .Values.webserver.serviceAccount.name }}
  {{- else }}
-   {{ tpl (default "default" .Values.webserver.serviceAccount.name) . }}
+   {{- tpl (default "default" .Values.webserver.serviceAccount.name) . -}}
  {{- end }}
 {{- end }}
 
 {{/* Create the name of the RPC server service account to use */}}
 {{- define "rpcServer.serviceAccountName" -}}
   {{- if .Values._rpcServer.serviceAccount.create }}
-    {{ default (printf "%s-rpc-server" (include "airflow.serviceAccountName" .)) .Values._rpcServer.serviceAccount.name }}
+    {{- default (printf "%s-rpc-server" (include "airflow.serviceAccountName" .)) .Values._rpcServer.serviceAccount.name }}
   {{- else }}
-    {{ tpl (default "default" .Values._rpcServer.serviceAccount.name) . }}
+    {{- tpl (default "default" .Values._rpcServer.serviceAccount.name) . -}}
   {{- end }}
 {{- end }}
 
@@ -619,7 +619,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.redis.serviceAccount.create }}
     {{- default (printf "%s-redis" (include "airflow.serviceAccountName" .)) .Values.redis.serviceAccount.name }}
   {{- else }}
-    {{ tpl (default "default" .Values.redis.serviceAccount.name) . }}
+    {{- tpl (default "default" .Values.redis.serviceAccount.name) . -}}
   {{- end }}
 {{- end }}
 
@@ -628,7 +628,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.flower.serviceAccount.create }}
     {{- default (printf "%s-flower" (include "airflow.serviceAccountName" .)) .Values.flower.serviceAccount.name }}
   {{- else }}
-    {{ tpl (default "default" .Values.flower.serviceAccount.name) . }}
+    {{- tpl (default "default" .Values.flower.serviceAccount.name) . -}}
   {{- end }}
 {{- end }}
 
@@ -637,7 +637,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.scheduler.serviceAccount.create }}
     {{- default (printf "%s-scheduler" (include "airflow.serviceAccountName" .)) .Values.scheduler.serviceAccount.name }}
   {{- else }}
-    {{ tpl (default "default" .Values.scheduler.serviceAccount.name) . }}
+    {{- tpl (default "default" .Values.scheduler.serviceAccount.name) . -}}
   {{- end }}
 {{- end }}
 
@@ -646,7 +646,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.statsd.serviceAccount.create }}
     {{- default (printf "%s-statsd" (include "airflow.serviceAccountName" .)) .Values.statsd.serviceAccount.name }}
   {{- else }}
-    {{ tpl (default "default" .Values.statsd.serviceAccount.name) . }}
+    {{- tpl (default "default" .Values.statsd.serviceAccount.name) . -}}
   {{- end }}
 {{- end }}
 
@@ -655,7 +655,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.createUserJob.serviceAccount.create }}
     {{- default (printf "%s-create-user-job" (include "airflow.serviceAccountName" .)) .Values.createUserJob.serviceAccount.name }}
   {{- else }}
-    {{ tpl (default "default" .Values.createUserJob.serviceAccount.name) . }}
+    {{- tpl (default "default" .Values.createUserJob.serviceAccount.name) . -}}
   {{- end }}
 {{- end }}
 
@@ -664,7 +664,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.migrateDatabaseJob.serviceAccount.create }}
     {{- default (printf "%s-migrate-database-job" (include "airflow.serviceAccountName" .)) .Values.migrateDatabaseJob.serviceAccount.name }}
   {{- else }}
-    {{ tpl (default "default" .Values.migrateDatabaseJob.serviceAccount.name) . }}
+    {{- tpl (default "default" .Values.migrateDatabaseJob.serviceAccount.name) . -}}
   {{- end }}
 {{- end }}
 
@@ -673,7 +673,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.workers.serviceAccount.create }}
     {{- default (printf "%s-worker" (include "airflow.serviceAccountName" .)) .Values.workers.serviceAccount.name }}
   {{- else }}
-    {{ tpl (default "default" .Values.workers.serviceAccount.name) . }}
+    {{- tpl (default "default" .Values.workers.serviceAccount.name) . -}}
   {{- end }}
 {{- end }}
 
@@ -682,7 +682,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.triggerer.serviceAccount.create }}
     {{- default (printf "%s-triggerer" (include "airflow.serviceAccountName" .)) .Values.triggerer.serviceAccount.name }}
   {{- else }}
-    {{ tpl (default "default" .Values.triggerer.serviceAccount.name) . }}
+    {{- tpl (default "default" .Values.triggerer.serviceAccount.name) . -}}
   {{- end }}
 {{- end }}
 
@@ -691,7 +691,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.dagProcessor.serviceAccount.create }}
     {{- default (printf "%s-dag-processor" (include "airflow.serviceAccountName" .)) .Values.dagProcessor.serviceAccount.name }}
   {{- else }}
-    {{ tpl (default "default" .Values.dagProcessor.serviceAccount.name) . }}
+    {{- tpl (default "default" .Values.dagProcessor.serviceAccount.name) . -}}
   {{- end }}
 {{- end }}
 
@@ -700,7 +700,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.pgbouncer.serviceAccount.create }}
     {{- default (printf "%s-pgbouncer" (include "airflow.serviceAccountName" .)) .Values.pgbouncer.serviceAccount.name }}
   {{- else }}
-    {{ tpl (default "default" .Values.pgbouncer.serviceAccount.name) . }}
+    {{- tpl (default "default" .Values.pgbouncer.serviceAccount.name) . -}}
   {{- end }}
 {{- end }}
 
@@ -709,7 +709,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.cleanup.serviceAccount.create }}
     {{- default (printf "%s-cleanup" (include "airflow.serviceAccountName" .)) .Values.cleanup.serviceAccount.name }}
   {{- else }}
-    {{ tpl (default "default" .Values.cleanup.serviceAccount.name) . }}
+    {{- tpl (default "default" .Values.cleanup.serviceAccount.name) . -}}
   {{- end }}
 {{- end }}
 

--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -601,7 +601,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
  {{- if .Values.webserver.serviceAccount.create }}
    {{ default (printf "%s-webserver" (include "airflow.serviceAccountName" .)) .Values.webserver.serviceAccount.name }}
  {{- else }}
-   {{- tpl .Values.webserver.serviceAccount.name . }}
+   {{tpl (default "default" .Values.webserver.serviceAccount.name) . }}
  {{- end }}
 {{- end }}
 
@@ -610,7 +610,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values._rpcServer.serviceAccount.create }}
     {{ default (printf "%s-rpc-server" (include "airflow.serviceAccountName" .)) .Values._rpcServer.serviceAccount.name }}
   {{- else }}
-    {{- tpl .Values._rpcServer.serviceAccount.name . }}
+    {{tpl (default "default" .Values._rpcServer.serviceAccount.name) . }}
   {{- end }}
 {{- end }}
 
@@ -619,7 +619,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.redis.serviceAccount.create }}
     {{- default (printf "%s-redis" (include "airflow.serviceAccountName" .)) .Values.redis.serviceAccount.name }}
   {{- else }}
-    {{- tpl .Values.redis.serviceAccount.name . }}
+    {{tpl (default "default" .Values.redis.serviceAccount.name) . }}
   {{- end }}
 {{- end }}
 
@@ -628,7 +628,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.flower.serviceAccount.create }}
     {{- default (printf "%s-flower" (include "airflow.serviceAccountName" .)) .Values.flower.serviceAccount.name }}
   {{- else }}
-    {{- tpl .Values.flower.serviceAccount.name . }}
+    {{tpl (default "default" .Values.flower.serviceAccount.name) . }}
   {{- end }}
 {{- end }}
 
@@ -637,7 +637,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.scheduler.serviceAccount.create }}
     {{- default (printf "%s-scheduler" (include "airflow.serviceAccountName" .)) .Values.scheduler.serviceAccount.name }}
   {{- else }}
-    {{- tpl .Values.scheduler.serviceAccount.name . }}
+    {{tpl (default "default" .Values.scheduler.serviceAccount.name) . }}
   {{- end }}
 {{- end }}
 
@@ -646,7 +646,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.statsd.serviceAccount.create }}
     {{- default (printf "%s-statsd" (include "airflow.serviceAccountName" .)) .Values.statsd.serviceAccount.name }}
   {{- else }}
-    {{- tpl .Values.statsd.serviceAccount.name . }}
+    {{tpl (default "default" .Values.statsd.serviceAccount.name) . }}
   {{- end }}
 {{- end }}
 
@@ -655,7 +655,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.createUserJob.serviceAccount.create }}
     {{- default (printf "%s-create-user-job" (include "airflow.serviceAccountName" .)) .Values.createUserJob.serviceAccount.name }}
   {{- else }}
-    {{- tpl .Values.createUserJob.serviceAccount.name . }}
+    {{tpl (default "default" .Values.createUserJob.serviceAccount.name) . }}
   {{- end }}
 {{- end }}
 
@@ -664,7 +664,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.migrateDatabaseJob.serviceAccount.create }}
     {{- default (printf "%s-migrate-database-job" (include "airflow.serviceAccountName" .)) .Values.migrateDatabaseJob.serviceAccount.name }}
   {{- else }}
-    {{- tpl .Values.migrateDatabaseJob.serviceAccount.name . }}
+    {{tpl (default "default" .Values.migrateDatabaseJob.serviceAccount.name) . }}
   {{- end }}
 {{- end }}
 
@@ -673,7 +673,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.workers.serviceAccount.create }}
     {{- default (printf "%s-worker" (include "airflow.serviceAccountName" .)) .Values.workers.serviceAccount.name }}
   {{- else }}
-    {{- tpl .Values.workers.serviceAccount.name . }}
+    {{tpl (default "default" .Values.workers.serviceAccount.name) . }}
   {{- end }}
 {{- end }}
 
@@ -682,7 +682,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.triggerer.serviceAccount.create }}
     {{- default (printf "%s-triggerer" (include "airflow.serviceAccountName" .)) .Values.triggerer.serviceAccount.name }}
   {{- else }}
-    {{- tpl .Values.triggerer.serviceAccount.name . }}
+    {{tpl (default "default" .Values.triggerer.serviceAccount.name) . }}
   {{- end }}
 {{- end }}
 
@@ -691,7 +691,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.dagProcessor.serviceAccount.create }}
     {{- default (printf "%s-dag-processor" (include "airflow.serviceAccountName" .)) .Values.dagProcessor.serviceAccount.name }}
   {{- else }}
-    {{- tpl .Values.dagProcessor.serviceAccount.name . }}
+    {{tpl (default "default" .Values.dagProcessor.serviceAccount.name) . }}
   {{- end }}
 {{- end }}
 
@@ -700,7 +700,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.pgbouncer.serviceAccount.create }}
     {{- default (printf "%s-pgbouncer" (include "airflow.serviceAccountName" .)) .Values.pgbouncer.serviceAccount.name }}
   {{- else }}
-    {{- tpl .Values.pgbouncer.serviceAccount.name . }}
+    {{tpl (default "default" .Values.pgbouncer.serviceAccount.name) . }}
   {{- end }}
 {{- end }}
 
@@ -709,7 +709,7 @@ server_tls_key_file = /etc/pgbouncer/server.key
   {{- if .Values.cleanup.serviceAccount.create }}
     {{- default (printf "%s-cleanup" (include "airflow.serviceAccountName" .)) .Values.cleanup.serviceAccount.name }}
   {{- else }}
-    {{- tpl .Values.cleanup.serviceAccount.name . }}
+    {{tpl (default "default" .Values.cleanup.serviceAccount.name) . }}
   {{- end }}
 {{- end }}
 


### PR DESCRIPTION
## Summary
This PR adds support for templated service account names across all Airflow components, allowing users to specify dynamic service account names using Helm template expressions.

## Changes Made
### Modified Service Account Helper Functions
Updated the following service account helper functions to support template processing:

- `webserver.serviceAccountName`
- `rpcServer.serviceAccountName`
- `redis.serviceAccountName`
- `flower.serviceAccountName`
- `scheduler.serviceAccountName`
- `statsd.serviceAccountName`
- `createUserJob.serviceAccountName`
- `migrateDatabaseJob.serviceAccountName`
- `workers.serviceAccountName`
- `triggerer.serviceAccountName`
- `dagProcessor.serviceAccountName`
- `pgbouncer.serviceAccountName`
- `cleanup.serviceAccountName`

### Template Processing Logic

- When `serviceAccount.create = true`: Uses existing logic with default function (no template processing needed for auto-created accounts)
- When `serviceAccount.create = false`: Applies tpl function to process user-provided template strings.

## Testing
- Verified template processing works correctly:
![Screenshot 2025-06-19 at 7 10 23 PM](https://github.com/user-attachments/assets/b1301845-7285-4596-9390-76a49bbb7312)

- Tested all the templates:
```
(SBOM) shubhamsingh@Shubhams-MacBook-Pro chart % helm template . --set _rpcServer.serviceAccount.create=false --set '_rpcServer.serviceAccount.name=\{\{ .Release.Name \}\}-rpc-server-sa' --set _rpcServer.enabled=true  --show-only templates/rpc-server/rpc-server-deployment.yaml | grep serviceAccountName
      serviceAccountName: release-name-rpc-server-sa
 
(SBOM) shubhamsingh@Shubhams-MacBook-Pro chart % helm template . --set webserver.serviceAccount.create=false --set 'webserver.serviceAccount.name=\{\{ .Release.Name \}\}-webserver-sa' --show-only templates/webserver/webserver-deployment.yaml | grep serviceAccountName
      serviceAccountName: release-name-webserver-sa

(SBOM) shubhamsingh@Shubhams-MacBook-Pro chart % helm template . --set redis.serviceAccount.create=false --set 'redis.serviceAccount.name=\{\{ .Release.Name \}\}-redis-sa' --show-only templates/redis/redis-statefulset.yaml | grep serviceAccountName
      serviceAccountName: release-name-redis-sa

(SBOM) shubhamsingh@Shubhams-MacBook-Pro chart % helm template . --set flower.serviceAccount.create=false --set 'flower.serviceAccount.name=\{\{ .Release.Name \}\}-flower-sa' --set flower.enabled=true  --show-only templates/flower/flower-deployment.yaml | grep serviceAccountName 
      serviceAccountName: release-name-flower-sa

(SBOM) shubhamsingh@Shubhams-MacBook-Pro chart % helm template . --set scheduler.serviceAccount.create=false --set 'scheduler.serviceAccount.name=\{\{ .Release.Name \}\}-scheduler-sa' --show-only templates/scheduler/scheduler-deployment.yaml | grep serviceAccountName
      serviceAccountName: release-name-scheduler-sa

(SBOM) shubhamsingh@Shubhams-MacBook-Pro chart % helm template . --set statsd.serviceAccount.create=false --set 'statsd.serviceAccount.name=\{\{ .Release.Name \}\}-statsd-sa' --show-only templates/statsd/statsd-deployment.yaml | grep serviceAccountName
      serviceAccountName: release-name-statsd-sa

(SBOM) shubhamsingh@Shubhams-MacBook-Pro chart % helm template . --set createUserJob.serviceAccount.create=false --set 'createUserJob.serviceAccount.name=\{\{ .Release.Name \}\}-create-user-sa' --show-only templates/jobs/create-user-job.yaml | grep serviceAccountName
      serviceAccountName: release-name-create-user-sa

(SBOM) shubhamsingh@Shubhams-MacBook-Pro chart % helm template . --set migrateDatabaseJob.serviceAccount.create=false --set 'migrateDatabaseJob.serviceAccount.name=\{\{ .Release.Name \}\}-migrate-db-sa' --show-only templates/jobs/migrate-database-job.yaml | grep serviceAccountName
      serviceAccountName: release-name-migrate-db-sa

(SBOM) shubhamsingh@Shubhams-MacBook-Pro chart % helm template . --set workers.serviceAccount.create=false --set 'workers.serviceAccount.name=\{\{ .Release.Name \}\}-worker-sa' --show-only templates/workers/worker-deployment.yaml | grep serviceAccountName
      serviceAccountName: release-name-worker-sa

(SBOM) shubhamsingh@Shubhams-MacBook-Pro chart % helm template . --set triggerer.serviceAccount.create=false --set 'triggerer.serviceAccount.name=\{\{ .Release.Name \}\}-triggerer-sa' --show-only templates/triggerer/triggerer-deployment.yaml | grep serviceAccountName
      serviceAccountName: release-name-triggerer-sa

(SBOM) shubhamsingh@Shubhams-MacBook-Pro chart % helm template . --set dagProcessor.serviceAccount.create=false --set 'dagProcessor.serviceAccount.name=\{\{ .Release.Name \}\}-dag-processor-sa' --set dagProcessor.enabled=true  --show-only templates/dag-processor/dag-processor-deployment.yaml | grep serviceAccountName
      serviceAccountName: release-name-dag-processor-sa

(SBOM) shubhamsingh@Shubhams-MacBook-Pro chart % helm template . --set pgbouncer.serviceAccount.create=false --set 'pgbouncer.serviceAccount.name=\{\{ .Release.Name \}\}-pgbouncer-sa' --set pgbouncer.enabled=true --show-only templates/pgbouncer/pgbouncer-deployment.yaml | grep serviceAccountName
      serviceAccountName: release-name-pgbouncer-sa

(SBOM) shubhamsingh@Shubhams-MacBook-Pro chart % helm template . --set cleanup.serviceAccount.create=false --set 'cleanup.serviceAccount.name=\{\{ .Release.Name \}\}-cleanup-sa' --set cleanup.enabled=true  --show-only templates/cleanup/cleanup-cronjob.yaml | grep serviceAccountName
          serviceAccountName: release-name-cleanup-sa
(SBOM) shubhamsingh@Shubhams-MacBook-Pro chart % 

```

## Related
https://github.com/astronomer/issues/issues/7365
