### PR TITLE
Add Missing Health Check Probes to Dag Processor Containers

### DIFF
--- a/chart/values.schema.json
+++ b/chart/values.schema.json
@@ -3839,6 +3839,46 @@
                         }
                     }
                 },
+                "readinessProbe": {
+                    "description": "Readiness probe configuration for dag processor.",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "initialDelaySeconds": {
+                            "description": "Number of seconds after the container has started before readiness probes are initiated.",
+                            "type": "integer",
+                            "default": 10
+                        },
+                        "timeoutSeconds": {
+                            "description": "Number of seconds after which the probe times out. Minimum value is 1 seconds.",
+                            "type": "integer",
+                            "default": 20
+                        },
+                        "failureThreshold": {
+                            "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Minimum value is 1.",
+                            "type": "integer",
+                            "default": 5
+                        },
+                        "periodSeconds": {
+                            "description": "How often (in seconds) to perform the probe. Minimum value is 1.",
+                            "type": "integer",
+                            "default": 60
+                        },
+                        "command": {
+                            "description": "Command for readinessProbe",
+                            "type": [
+                                "array",
+                                "null"
+                            ],
+                            "items": {
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            }
+                        }
+                    }
+                },
                 "replicas": {
                     "description": "Number of dag processors to run.",
                     "type": "integer",


### PR DESCRIPTION
## Summary
This PR adds missing health check probes (readiness and liveness probes) to dag processor containers.

## Background
During our audit of container health checks for the 0.37.3 release, we discovered that while the dag-processor deployment template supported probe configurations, some containers were missing essential health checks:

- `dag-processor` container: Had `livenessProbe` but was missing `readinessProbe`
- `dag-processor-log-groomer` container: Had probe configurations in schema but they were disabled by default.

This was part of a broader initiative to ensure all containers have proper health check probes and resources configured.

## Changes Made

 ### Health Check Probe Additions

`dag-processor` container: Enabled `readinessProbe` configuration (was conditionally rendered but not documented)
`dag-processor-log-groomer` container: Documented and validated existing `livenessProbe` and `readinessProbe` configurations.

## Configuration Examples
 ### Enable dag-processor readiness probe:
```
dagProcessor:
  enabled: true
  readinessProbe:
    initialDelaySeconds: 10
    timeoutSeconds: 20
    failureThreshold: 5
    periodSeconds: 60
```
 ### Enable log groomer probes:
```
dagProcessor:
  logGroomerSidecar:
    enabled: true
    livenessProbe:
      enabled: true
      initialDelaySeconds: 60
      timeoutSeconds: 20
      failureThreshold: 5
      periodSeconds: 60
    readinessProbe:
      enabled: true
      initialDelaySeconds: 60
      timeoutSeconds: 20
      failureThreshold: 5
      periodSeconds: 60
```

## Testing

- Manually tested the template rendering:
  - Testing dag-processor readiness probe 
```
helm template . --show-only templates/dag-processor/dag-processor-deployment.yaml \
  --set dagProcessor.enabled=true \
  --set dagProcessor.readinessProbe.initialDelaySeconds=10
```
![Screenshot 2025-06-20 at 2 12 40 PM](https://github.com/user-attachments/assets/013acd31-8129-4315-a9f0-3784d8dee05e)

  - Test log groomer probes
```
helm template . --show-only templates/dag-processor/dag-processor-deployment.yaml \
  --set dagProcessor.enabled=true \
  --set dagProcessor.logGroomerSidecar.enabled=true \
  --set dagProcessor.logGroomerSidecar.livenessProbe.enabled=true \
  --set dagProcessor.logGroomerSidecar.readinessProbe.enabled=true
```
![Screenshot 2025-06-20 at 2 13 13 PM](https://github.com/user-attachments/assets/44951665-8b70-4c07-9cb7-985477ec3935)

