### PR TITLE
Fix Log Groomer Sidecar Health Check Failures

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -19,7 +19,7 @@
 ---
 apiVersion: v2
 name: airflow
-version: 1.15.3-astro
+version: 1.15.4-astro
 appVersion: 2.10.2
 description: The official Helm chart to deploy Apache Airflow, a platform to
   programmatically author, schedule, and monitor workflows

--- a/chart/templates/dag-processor/dag-processor-deployment.yaml
+++ b/chart/templates/dag-processor/dag-processor-deployment.yaml
@@ -241,10 +241,6 @@ spec:
               command:
               {{- if .Values.scheduler.logGroomerSidecar.livenessProbe.command }}
                 {{- toYaml .Values.scheduler.logGroomerSidecar.livenessProbe.command | nindent 16 }}
-              {{- else }}
-                - sh
-                - -c
-                - "test -f /clean-logs && grep -q 'AIRFLOW__LOG_RETENTION_DAYS' /clean-logs"
               {{- end }}
           {{- end }}
 
@@ -258,10 +254,6 @@ spec:
               command:
               {{- if .Values.scheduler.logGroomerSidecar.readinessProbe.command }}
                 {{- toYaml .Values.scheduler.logGroomerSidecar.readinessProbe.command | nindent 16 }}
-                {{- else }}
-                - sh
-                - -c
-                - "test -e /clean-logs"
               {{- end }}
           {{- end }}
 

--- a/chart/templates/workers/worker-deployment.yaml
+++ b/chart/templates/workers/worker-deployment.yaml
@@ -342,10 +342,6 @@ spec:
               command:
               {{- if hasKey .Values.workers.logGroomerSidecar.livenessProbe "command" }}
                 {{- toYaml .Values.workers.logGroomerSidecar.livenessProbe.command | nindent 16 }}
-              {{- else }}
-                - sh
-                - -c
-                - "test -f /clean-logs && grep -q 'AIRFLOW__LOG_RETENTION_DAYS' /clean-logs"
               {{- end }}
           {{- end }}
           {{- if hasKey .Values.workers.logGroomerSidecar "readinessProbe" }}
@@ -358,10 +354,6 @@ spec:
               command:
               {{- if hasKey .Values.workers.logGroomerSidecar.readinessProbe "command" }}
                 {{- toYaml .Values.workers.logGroomerSidecar.readinessProbe.command | nindent 16 }}
-              {{- else }}
-                - sh
-                - -c
-                - "test -e /clean-logs"
               {{- end }}
           {{- end }}
           {{- if .Values.workers.logGroomerSidecar.command }}


### PR DESCRIPTION
## Description

The DAG Processor pods were failing readiness and liveness probes for the log groomer sidecar containers. The probes were checking for a /clean-logs file that doesn't exist:

### Failing Probes:

 - Liveness: test -f /clean-logs && grep -q 'AIRFLOW__LOG_RETENTION_DAYS' /clean-logs
 - Readiness: test -e /clean-logs

This caused pods to be marked as Not Ready and triggered unnecessary container restarts, even though the log groomer was functioning correctly.

## Root Cause

The health check logic assumed the log groomer script (/usr/local/bin/clean-airflow-logs) has a `/clean-logs` file, but this file is never actually present in the container. The probes were based on incorrect assumptions about the script's behavior.

## Solution
Removed the problematic /clean-logs file checks from both DAG Processor and Worker log groomer sidecar containers.

## Related

https://github.com/astronomer/issues/issues/7338

