### PR TITLE
[Do not merge] POC for `SparkStandaloneExecutor`

### DIFF
--- a/airflow-core/src/airflow/jobs/scheduler_job_runner.py
+++ b/airflow-core/src/airflow/jobs/scheduler_job_runner.py
@@ -1394,6 +1394,23 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     ti.set_state(None)
                     continue
 
+                # Handle executors that complete tasks without going through the
+                # Execution API (e.g. Spark JAR tasks submitted by
+                # SparkStandaloneExecutor, or any future executor that manages
+                # non-Python workloads directly).  The task never called the
+                # Execution API so it stayed QUEUED/RUNNING in the DB, but the
+                # executor is explicitly reporting that it finished successfully.
+                # Respect the executor's result instead of treating this as
+                # "killed externally".
+                if state == TaskInstanceState.SUCCESS:
+                    cls.logger().info(
+                        "Task %s was reported as successful by executor without an "
+                        "Execution API transition; marking as success.",
+                        ti,
+                    )
+                    ti.set_state(TaskInstanceState.SUCCESS, session=session)
+                    continue
+
                 # Send email notification request to DAG processor via DB
                 if task.email and (task.email_on_failure or task.email_on_retry):
                     cls.logger().info(

--- a/dev/spark-standalone/AirflowDriverLauncher.java
+++ b/dev/spark-standalone/AirflowDriverLauncher.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * JVM entry point for SparkStandaloneExecutor drivers.
+ *
+ * Spark Standalone cluster deploy mode does not support Python applications
+ * directly, so we submit this JVM shim instead.  It launches the Python task
+ * runner as a subprocess and waits for it to exit, propagating the exit code.
+ *
+ * All environment variables set by SparkStandaloneExecutor (including
+ * AIRFLOW_EXECUTE_WORKLOAD) are inherited by the subprocess automatically.
+ *
+ * The Python script path is read from AIRFLOW_TASK_RUNNER_SCRIPT, defaulting
+ * to /opt/airflow/scripts/airflow_task_runner.py.
+ */
+public class AirflowDriverLauncher {
+    public static void main(String[] args) throws Exception {
+        String script = System.getenv().getOrDefault(
+            "AIRFLOW_TASK_RUNNER_SCRIPT",
+            "/opt/airflow/scripts/airflow_task_runner.py"
+        );
+        System.out.println("[AirflowDriverLauncher] launching python3 " + script);
+        ProcessBuilder pb = new ProcessBuilder("python3", script);
+        pb.inheritIO();
+        int exitCode = pb.start().waitFor();
+        System.out.println("[AirflowDriverLauncher] python3 exited with code " + exitCode);
+        System.exit(exitCode);
+    }
+}

--- a/dev/spark-standalone/DEMO.md
+++ b/dev/spark-standalone/DEMO.md
@@ -1,0 +1,164 @@
+# SparkStandaloneExecutor — Demo Script
+
+**Runtime:** ~5 minutes
+**Goal:** Show a normal `@task` function getting a live SparkSession — no `SparkSubmitOperator`, no DAG changes.
+
+---
+
+## Intro (~30 sec)
+
+**Say:**
+> If you want to run an Airflow task on Spark today, you have to use SparkSubmitOperator. That means a separate operator in every DAG, a standalone Python file deployed to the cluster, and a Spark connection configured by your platform team. It works — but it means every DAG author has to make infrastructure decisions.
+>
+> KubernetesExecutor solved this for Kubernetes: one config change, and every task runs in a pod. Nobody writes KubernetesPodOperator for every task anymore.
+>
+> Spark has never had that moment. This is that moment.
+
+---
+
+## Before You Start
+
+Have three browser tabs open:
+
+| Tab | URL |
+|-----|-----|
+| Airflow UI | http://localhost:28080 |
+| Spark Master UI | http://localhost:8080 |
+| MinIO Console | http://localhost:9001 (`minioadmin` / `minioadmin`) |
+
+---
+
+## Step 1 — Start the cluster
+
+```bash
+cd dev/spark-standalone
+docker compose up --build -d
+docker compose run --rm minio-init
+```
+
+**Show:** Spark Master UI at http://localhost:8080. Two workers listed as ALIVE.
+
+**Say:**
+> We have a Spark Standalone cluster running locally in Docker — one master, two workers — and a MinIO instance for log storage.
+
+---
+
+## Step 2 — Start Airflow
+
+```bash
+breeze start-airflow --backend postgres --db-reset
+```
+
+**Show:** Open `files/airflow-breeze-config/spark-standalone.sh` and point to this line:
+
+```bash
+AIRFLOW__CORE__EXECUTOR=...SparkStandaloneExecutor
+```
+
+**Say:**
+> This is the only change to Airflow's configuration. One line. No changes to any DAG.
+
+---
+
+## Step 3 — Show the DAG
+
+Airflow UI → search `spark_word_count` → **Code** tab. Scroll to `count_words` and highlight:
+
+```python
+@task
+def count_words(lines: list[str]) -> dict[str, int]:
+    from pyspark.sql import SparkSession
+
+    spark = SparkSession.builder.getOrCreate()  # live session — no operator needed
+    ...
+```
+
+**Say:**
+> This is a completely normal Python function. It calls SparkSession dot builder dot getOrCreate, and it gets back a real, live Spark session — because SparkStandaloneExecutor submits this task to the Spark cluster as a driver process. The person writing this DAG doesn't configure Spark, doesn't write a submit operator, doesn't maintain a separate application file. They just write Python.
+
+**Show:** `prepare_text` and `report_top_words`.
+
+**Say:**
+> The other two tasks don't use Spark at all. They still run on the cluster — the executor handles that transparently.
+
+---
+
+## Step 4 — Trigger
+
+Click **Trigger DAG**.
+
+**Say:**
+> Let's run it.
+
+---
+
+## Step 5 — Watch on the Spark UI
+
+Switch to http://localhost:8080. Watch tasks appear under **Running Applications**:
+
+```
+airflow-spark_word_count-count_words-...    RUNNING
+```
+
+**Say:**
+> Each Airflow task shows up here as a Spark application. That's count_words running on a worker right now — submitted by the executor, not by any operator in the DAG.
+
+Wait for tasks to move to **Completed Applications**.
+
+---
+
+## Step 6 — View logs in Airflow
+
+Airflow UI → click the `count_words` task box → **Logs**.
+
+Point to:
+```
+Spark version : 4.0.1
+Application ID: local-...
+```
+
+Scroll to the bottom:
+```
+────────────────────────────────────────
+  Top 15 words
+────────────────────────────────────────
+  spark                 8  ████████████████████
+  airflow               6  ███████████████
+  ...
+────────────────────────────────────────
+```
+
+**Say:**
+> The logs come from MinIO — the Spark driver wrote them directly to the bucket, and Airflow reads them from there. No serve-logs daemon running on the worker containers.
+
+---
+
+## Step 7 — MinIO (optional)
+
+http://localhost:9001 → `airflow-logs` bucket → browse to the log file.
+
+**Say:**
+> And here are the raw files in the bucket. Same content, directly accessible.
+
+---
+
+## Closing
+
+**Say:**
+> A normal Airflow task function. A live SparkSession. Logs stored in S3. All from one line in the config. That's SparkStandaloneExecutor.
+
+---
+
+## If questions come up
+
+**Tasks that don't need Spark?**
+> They still run on the cluster as driver processes — they just don't call getOrCreate. No extra configuration needed.
+
+**Does this work with existing DAGs?**
+> Yes. You get a SparkSession only if you ask for one. Existing tasks run unchanged.
+
+**Resource overrides per task?**
+> Use executor_config: `@task(executor_config={"spark_properties": {"spark.driver.memory": "2g"}})`. Any Spark property works.
+
+**Why not just use SparkSubmitOperator?**
+> You still can — it's still there. This is for teams that want Spark as the execution layer without baking it into every DAG.

--- a/dev/spark-standalone/Dockerfile
+++ b/dev/spark-standalone/Dockerfile
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Spark worker image with the Airflow Task SDK installed.
+#
+# This is what makes SparkStandaloneExecutor equivalent to KubernetesExecutor:
+# the Spark driver process can call `execute_workload` to run real Airflow tasks,
+# exactly as a Kubernetes Pod does.
+#
+# Build:   docker build -t airflow-spark:latest dev/spark-standalone/
+# Or via:  docker compose up --build
+
+FROM spark:python3
+
+USER root
+
+# Install the Airflow Task SDK — the only Airflow component needed on workers.
+# This is equivalent to the Airflow image used by KubernetesExecutor.
+RUN pip install --no-cache-dir apache-airflow-task-sdk
+
+# Copy the Python task runner.
+RUN mkdir -p /opt/airflow/scripts /opt/airflow/jars
+COPY scripts/airflow_task_runner.py /opt/airflow/scripts/airflow_task_runner.py
+
+# Build the JVM shim that launches the Python task runner.
+# Spark Standalone cluster mode does not support Python appResource directly;
+# we submit this JAR instead and it spawns python3 as a subprocess.
+COPY AirflowDriverLauncher.java /tmp/AirflowDriverLauncher.java
+RUN cd /tmp \
+    && javac AirflowDriverLauncher.java \
+    && jar cf /opt/airflow/jars/airflow-driver-launcher.jar AirflowDriverLauncher.class \
+    && rm AirflowDriverLauncher.java AirflowDriverLauncher.class
+
+# spark:python3 runs as the `spark` user (uid 185); keep that convention.
+USER spark

--- a/dev/spark-standalone/Dockerfile
+++ b/dev/spark-standalone/Dockerfile
@@ -28,9 +28,21 @@ FROM spark:python3
 
 USER root
 
-# Install the Airflow Task SDK — the only Airflow component needed on workers.
-# This is equivalent to the Airflow image used by KubernetesExecutor.
-RUN pip install --no-cache-dir apache-airflow-task-sdk
+# Install the Airflow Task SDK, S3 logging provider, and pyspark.
+#
+# pyspark is installed explicitly here even though spark:python3 ships it,
+# because our driver processes are launched as subprocesses of a JVM shim
+# (AirflowDriverLauncher) and do not go through Spark's normal Python
+# bootstrap that sets up PYTHONPATH.  A regular pip install makes pyspark
+# importable without any PYTHONPATH magic.
+#
+# The pyspark version is pinned to the Spark version already present in the
+# base image so the Python bindings match the running JVM.
+RUN SPARK_VER=$(cat /opt/spark/RELEASE | awk 'NR==1{print $2}') \
+    && pip install --no-cache-dir \
+         apache-airflow-task-sdk \
+         apache-airflow-providers-amazon \
+         "pyspark==${SPARK_VER}"
 
 # Copy the Python task runner.
 RUN mkdir -p /opt/airflow/scripts /opt/airflow/jars
@@ -44,6 +56,13 @@ RUN cd /tmp \
     && javac AirflowDriverLauncher.java \
     && jar cf /opt/airflow/jars/airflow-driver-launcher.jar AirflowDriverLauncher.class \
     && rm AirflowDriverLauncher.java AirflowDriverLauncher.class
+
+# Explicitly set PYTHONPATH so pip-installed packages are visible to python3
+# subprocesses spawned by the JVM shim.  When the Spark Worker launches our
+# driver JVM, it inherits a minimal environment (only SPARK_HOME + PATH).
+# Without this, site.py may not locate /usr/local/lib/python3.10/dist-packages
+# and pyspark/airflow-sdk imports fail inside the driver.
+ENV PYTHONPATH=/usr/local/lib/python3.10/dist-packages:/opt/spark/python
 
 # spark:python3 runs as the `spark` user (uid 185); keep that convention.
 USER spark

--- a/dev/spark-standalone/README.md
+++ b/dev/spark-standalone/README.md
@@ -1,103 +1,305 @@
-# SparkStandaloneExecutor — POC
+# SparkStandaloneExecutor
 
-Demonstrates the `SparkStandaloneExecutor`: an Airflow executor that submits
-every task to a Spark Standalone cluster via the REST Submission API.
+> **TL;DR** — `KubernetesExecutor` lets you run any Airflow task on Kubernetes without touching your DAGs. This is the same thing for Spark Standalone clusters.
 
-## The problem it solves
+---
 
-Today, running a task on Spark requires an explicit operator in every DAG:
+## Who This Is For
+
+**Spark shops** — organisations whose data platform runs on a Spark Standalone cluster (on-premises hardware, bare-metal cloud, or a managed Spark service without Kubernetes). This includes:
+
+- Firms running multi-petabyte Spark deployments on-prem, where Kubernetes is not available or not approved.
+- Teams that evaluated `KubernetesExecutor` but cannot adopt it because their compute is Spark, not Kubernetes.
+- Data engineering teams that want to use Airflow for orchestration but cannot accept the per-task boilerplate that `SparkSubmitOperator` requires.
+
+---
+
+## The Gap
+
+Spark is one of the most widely deployed distributed compute engines in the world, and Airflow is one of the most widely deployed orchestrators. Yet there is no first-class way to run Airflow tasks *on* a Spark cluster.
+
+The only option today is `SparkSubmitOperator`: a task-level operator that submits a standalone Python application file to Spark. It works, but it forces every team to make a choice at DAG-authoring time — "does this task run on Spark or not?" — and to maintain a separate application file for every Spark task. If you want a `SparkSession` inside a task, you cannot write a regular `@task` function; you must restructure the entire task as a Spark application.
+
+Compare this to Kubernetes. Before `KubernetesExecutor` existed, the only option was `KubernetesPodOperator` — one operator per task, with image names and resource requests baked into DAG code. Then `KubernetesExecutor` arrived and made the entire question disappear at the DAG level: configure the executor once, and every task runs in a pod. DAG authors write normal Python.
+
+**Spark has never had its `KubernetesExecutor` moment (yet). This POC is that moment.**
+
+---
+
+## The Problem in Code
+
+Running Airflow tasks on Spark today requires every DAG author to explicitly wrap their logic in a Spark operator:
 
 ```python
-# Must change every DAG that needs Spark
 from airflow.providers.apache.spark.operators.spark_submit import SparkSubmitOperator
 
-transform = SparkSubmitOperator(task_id="transform", application="job.py", ...)
+transform = SparkSubmitOperator(
+    task_id="transform",
+    application="/opt/jobs/transform.py",   # ← separate file which is deployed to the spark cluster
+    conn_id="spark_default",
+    executor_memory="4g",
+    num_executors=10,
+    ...
+)
 ```
 
-`SparkStandaloneExecutor` follows the same pattern as `KubernetesExecutor`:
-**change the executor config once, no DAG changes needed.** Every task runs on
-the Spark cluster. Tasks that call `SparkSession.builder.getOrCreate()` get a
-live session for free — they are running inside a Spark driver process.
+Every task that needs Spark requires:
+1. A separate `.py` application file maintained alongside the DAG
+2. An explicit `SparkSubmitOperator` (or `SparkKubernetesOperator`) in the DAG
+3. A Spark connection configured by the platform team
+4. Knowledge of Spark submit parameters baked into the DAG
 
-## Architecture
+This means moving a pipeline to Spark is a DAG rewrite, not a config change.
+
+---
+
+## The Solution
+
+`SparkStandaloneExecutor` solves this the same way `KubernetesExecutor` solved it for Kubernetes: **configure the executor once, and every task runs on Spark transparently.**
+
+```ini
+# airflow.cfg — one change, affects all DAGs
+[core]
+executor = airflow.providers.apache.spark.executors.spark_standalone_executor.SparkStandaloneExecutor
+```
+
+From that point on, a completely ordinary `@task` function gets a live `SparkSession` for free:
+
+```python
+@task
+def heavy_transform(rows: int) -> int:
+    from pyspark.sql import SparkSession          # ← just works
+    spark = SparkSession.builder.getOrCreate()    # ← returns the driver's session
+    return spark.range(rows).selectExpr("sum(id) as s").collect()[0]["s"]
+```
+
+No `SparkSubmitOperator`. No standalone application file. No Spark connection configuration per task. The task author writes normal Python; the executor takes care of everything else.
+
+---
+
+## How It Works
 
 ```
-Scheduler
-  └─► SparkStandaloneExecutor
-        └─► POST /v1/submissions/create   (Spark REST API on port 6066)
-              └─► Spark worker runs airflow_task_runner.py as driver
-                    └─► SparkSession available natively
-        └─► GET /v1/submissions/status/{id}  (polls until FINISHED/FAILED)
+Airflow Scheduler
+  └─► SparkStandaloneExecutor._process_workloads()
+        │
+        │  POST /v1/submissions/create
+        │  payload: { appResource: airflow-driver-launcher.jar,
+        │             mainClass:   AirflowDriverLauncher,
+        │             environmentVariables: { AIRFLOW_EXECUTE_WORKLOAD: <json> } }
+        ▼
+      Spark Master (REST API, port 6066)
+        └─► Spark Worker spawns driver JVM process
+              └─► AirflowDriverLauncher.main()
+                    └─► python3 airflow_task_runner.py
+                          └─► airflow.sdk.execution_time.execute_workload
+                                ├─► SparkSession.builder.getOrCreate()  ← live session
+                                └─► communicates back to Airflow via Execution API
+
+  SparkStandaloneExecutor.sync()
+    └─► GET /v1/submissions/status/{id}
+          └─► driverState: FINISHED → task success
+              driverState: FAILED   → task failure
 ```
 
-## Prerequisites
+### Why a JVM shim?
+
+Spark Standalone cluster mode does not support Python as a primary `appResource`
+(`spark-submit --deploy-mode cluster script.py` explicitly fails with
+*"Cluster deploy mode is currently not supported for python applications on standalone clusters"*).
+
+The `AirflowDriverLauncher` JAR is a minimal Java class that is submitted as the real
+`appResource`. Its only job is to read `AIRFLOW_TASK_RUNNER_SCRIPT` from the environment and
+spawn `python3 <script>` as a subprocess with all environment variables inherited. This lets
+us pass the full serialised `ExecuteTask` workload through `AIRFLOW_EXECUTE_WORKLOAD` and
+have the Python task runner execute it on the Spark worker exactly as `KubernetesExecutor`
+does inside a Pod.
+
+---
+
+## SparkSubmitOperator vs SparkStandaloneExecutor
+
+| | `SparkSubmitOperator` | `SparkStandaloneExecutor` |
+|---|---|---|
+| **Change needed per DAG** | Yes — replace every task with a Spark operator | No — configure executor once |
+| **Task author needs to know about Spark** | Yes — must write standalone `.py` app file | No — regular `@task` function |
+| **`SparkSession` availability** | Inside the submitted application | Inside every task automatically |
+| **Non-Spark tasks** | Run on regular workers; only Spark tasks use Spark | All tasks run on Spark cluster |
+| **Resource overrides** | Per-task `num_executors`, `executor_memory`, etc. | Per-task via `executor_config={"spark_properties": {...}}` |
+| **XCom, callbacks, retries** | Partial — Airflow wraps the submitted job | Full — runs through the Airflow Task SDK |
+| **Analogue** | `KubernetesPodOperator` | `KubernetesExecutor` |
+
+---
+
+## What Is Now Possible
+
+**Before** (without this executor):
+
+- A data engineer who wants `SparkSession` must restructure their task as a standalone Spark application, add a `SparkSubmitOperator` to the DAG, configure a Spark connection, and maintain a separate Python file deployed to the cluster.
+- Moving an existing pipeline to Spark requires rewriting every affected task.
+- You cannot mix "this task uses Spark" and "this task does not" without explicit operator choices in the DAG.
+
+**After** (with `SparkStandaloneExecutor`):
+
+- Any `@task` function can call `SparkSession.builder.getOrCreate()` and receive a real, distributed session on the Spark cluster.
+- Existing DAGs that do not use Spark still run correctly — they simply run as driver processes without requesting a session.
+- Infra teams can move an entire Airflow deployment onto Spark by changing one line in `airflow.cfg`.
+- Resource allocation (`spark.driver.memory`, `spark.executor.cores`, etc.) is managed centrally with optional per-task overrides.
+- Task logs are written to S3-compatible storage (MinIO in the POC) and are readable in the Airflow UI without any additional infrastructure.
+
+---
+
+## Who / What This Unblocks
+
+**For Airflow users:**
+Organisations running Spark Standalone on-prem can now adopt Airflow as their orchestrator without being forced onto Kubernetes and without restructuring every DAG. Data engineers and scientists write plain Python tasks; the platform team configures the executor once.
+
+**For Airflow the project:**
+This is a direct proof-of-concept for AIP-72 (task execution on arbitrary compute). The task runner uses the same `execute_workload` entry point as `KubernetesExecutor`, which means full token propagation, heartbeats, and XCom over the Execution API all work without any changes. Adding Spark Standalone support to Airflow now costs one executor class and a thin JVM shim.
+
+**As a template:**
+The submission pattern — `POST to REST API → poll status → propagate env vars` — is the same pattern used by Livy, YARN, and the Databricks Jobs API. A `LivyExecutor` or `DatabricksExecutor` following this POC would require only a different REST client, not a new architecture.
+
+---
+
+## Running the POC
+
+### Prerequisites
 
 - Docker + Docker Compose
-- Airflow with the `apache-airflow-providers-apache-spark` provider installed
+- The Airflow repo checked out and Breeze available (`uv tool install breeze` or `pip install apache-airflow-breeze`)
 
-## Quick start
-
-### 1. Start the Spark cluster
+### 1 — Start the Spark cluster and MinIO
 
 ```bash
 cd dev/spark-standalone
-docker compose up -d
+docker compose up --build -d
+docker compose run --rm minio-init   # creates the airflow-logs bucket
 ```
 
-Verify the cluster is up:
-- Spark Master UI: http://localhost:8080
-- REST API: `curl http://localhost:6066/v1/submissions/status/test` should return JSON
+Services started:
 
-### 2. Configure Airflow
+| Service | URL | Purpose |
+|---------|-----|---------|
+| Spark Master | http://localhost:8080 | Spark cluster UI |
+| Spark REST API | http://localhost:6066 | Task submission endpoint |
+| MinIO S3 API | http://localhost:9000 | Remote log storage |
+| MinIO Console | http://localhost:9001 | Browse buckets / logs (admin: `minioadmin`) |
 
-Add to `airflow.cfg`:
+### 2 — Start Airflow (Breeze)
 
-```ini
-[core]
-executor = airflow.providers.apache.spark.executors.spark_standalone_executor.SparkStandaloneExecutor
-
-[spark_standalone_executor]
-master_url            = spark://localhost:7077
-rest_url              = http://localhost:6066/v1/submissions
-task_runner_script    = file:///opt/airflow/scripts/airflow_task_runner.py
-spark_version         = 3.5.0
-driver_memory         = 512m
-executor_memory       = 1g
-executor_cores        = 1
-startup_timeout       = 30
-submission_timeout    = 30
-```
-
-### 3. Trigger the demo DAG
+`files/airflow-breeze-config/spark-standalone.sh` is sourced automatically by Breeze on startup
+and sets all required env vars. Just start Breeze normally:
 
 ```bash
-airflow dags trigger demo_spark_standalone_executor
+breeze start-airflow --backend postgres --db-reset
 ```
 
-Or through the Airflow UI.
+Breeze connects to the Spark cluster and MinIO via `host.docker.internal` (the Docker host).
 
-## Per-task Spark resource overrides
+### 3 — Trigger the demo DAG
 
-Tasks can request additional resources via `executor_config`:
+Open the Airflow UI at http://localhost:28080, find the `demo_spark_standalone_executor` DAG
+(tagged `spark`, `poc`), and trigger it manually.
+
+The DAG has three tasks that run in sequence:
+
+```
+ingest  →  heavy_transform  →  publish
+```
+
+- `ingest`: lightweight ingestion step; demonstrates a task running on Spark without needing a session.
+- `heavy_transform`: calls `SparkSession.builder.getOrCreate()` and runs a distributed sum over 1 million rows.
+- `publish`: lightweight publish step with no Spark dependency.
+
+### 4 — Watch task execution on Spark
+
+While the DAG runs, open http://localhost:8080 to see the Spark Master UI. Each Airflow task appears as a running application (`airflow-<dag>-<task>-<run_id>`).
+
+### 5 — View task logs in the Airflow UI
+
+Click any completed task instance → **Logs**. Logs are fetched from MinIO (`s3://airflow-logs/`) — no `serve-logs` daemon required on the Spark workers.
+
+To browse the raw log files: open the MinIO console at http://localhost:9001 → `airflow-logs` bucket.
+
+---
+
+## Per-task Resource Overrides
 
 ```python
-@task(executor_config={"spark_properties": {"spark.executor.memory": "4g", "spark.executor.cores": "4"}})
+@task(executor_config={
+    "spark_properties": {
+        "spark.driver.memory":    "2g",
+        "spark.executor.memory":  "4g",
+        "spark.executor.cores":   "4",
+    }
+})
 def heavy_job():
     ...
 ```
 
-## Limitations (POC scope)
+Any `spark.*` property accepted by the REST Submission API can be set here.
 
-| Limitation | Status |
-|---|---|
-| Full Airflow task SDK integration | TODO — stub in `airflow_task_runner.py`. Blocked on [AIP-72 token propagation](https://github.com/apache/airflow/issues/45107) |
-| YARN / Kubernetes cluster managers | Not supported — use Livy or `SparkKubernetesExecutor` |
-| Task log streaming from Spark UI | Not implemented |
-| Callbacks (`on_failure_callback` etc.) | Not implemented |
+---
 
-## Running the tests
+## Configuration Reference
+
+All settings live under `[spark_standalone_executor]` in `airflow.cfg` (or as env vars with the `AIRFLOW__SPARK_STANDALONE_EXECUTOR__` prefix).
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `master_url` | `spark://localhost:7077` | Spark master URL passed inside submitted jobs |
+| `rest_url` | `http://localhost:6066/v1/submissions` | Base URL of the REST Submission API |
+| `task_runner_script` | `/opt/airflow/scripts/airflow_task_runner.py` | Path to the Python entry point on workers |
+| `driver_launcher_jar` | `file:///opt/airflow/jars/airflow-driver-launcher.jar` | Path to the JVM shim JAR on workers |
+| `spark_version` | `3.5.0` | Version reported to the REST API (must match cluster) |
+| `driver_memory` | `512m` | Default driver memory |
+| `executor_memory` | `1g` | Default executor memory |
+| `executor_cores` | `1` | Default executor cores |
+| `startup_timeout` | `30` | Seconds to wait for REST API during `start()` |
+| `submission_timeout` | `30` | Seconds to wait per submission request |
+
+---
+
+## Repo Layout
+
+```
+dev/spark-standalone/
+├── Dockerfile                     # Spark worker image: spark:python3 + task-sdk + providers-amazon
+├── docker-compose.yml             # Spark master, 2 workers, MinIO, minio-init
+├── AirflowDriverLauncher.java     # JVM shim: submits as appResource, spawns python3
+├── scripts/
+│   └── airflow_task_runner.py     # Python entry point run inside the Spark driver
+├── dags/
+│   └── demo_spark_standalone_executor.py   # Demo DAG (also in files/test_dags/)
+└── env.sh                         # Convenience env vars for running Airflow on the host (non-Breeze)
+
+files/airflow-breeze-config/
+└── spark-standalone.sh            # Sourced by init.sh; configures all Airflow env vars for Breeze
+
+providers/apache/spark/src/airflow/providers/apache/spark/executors/
+└── spark_standalone_executor.py   # The executor implementation
+
+providers/apache/spark/tests/unit/apache/spark/executors/
+└── test_spark_standalone_executor.py   # Unit tests (15 tests, all passing)
+```
+
+---
+
+## Running the Tests
 
 ```bash
-uv run --project providers/apache/spark pytest \
-  providers/apache/spark/tests/unit/apache/spark/executors/test_spark_standalone_executor.py -xvs
+uv run --project providers/apache/spark \
+  pytest providers/apache/spark/tests/unit/apache/spark/executors/test_spark_standalone_executor.py -xvs
 ```
+
+---
+
+## Known Limitations (POC scope)
+
+| Limitation | Notes |
+|---|---|
+| YARN / Kubernetes Spark cluster managers | Not supported. Use `SparkKubernetesOperator` or Livy for those. |
+| `spark:python3` image is Spark 4.0 | The official `spark:python3` image ships Spark 4.0. Set `spark_version = 4.0.1` in config. |
+| All tasks run on Spark | There is no per-task opt-out in this POC. A production implementation could check `executor_config` for an opt-out flag. |
+| Task timeouts | Submission timeout is configurable; driver-level task timeouts are not yet wired. |

--- a/dev/spark-standalone/README.md
+++ b/dev/spark-standalone/README.md
@@ -1,0 +1,103 @@
+# SparkStandaloneExecutor — POC
+
+Demonstrates the `SparkStandaloneExecutor`: an Airflow executor that submits
+every task to a Spark Standalone cluster via the REST Submission API.
+
+## The problem it solves
+
+Today, running a task on Spark requires an explicit operator in every DAG:
+
+```python
+# Must change every DAG that needs Spark
+from airflow.providers.apache.spark.operators.spark_submit import SparkSubmitOperator
+
+transform = SparkSubmitOperator(task_id="transform", application="job.py", ...)
+```
+
+`SparkStandaloneExecutor` follows the same pattern as `KubernetesExecutor`:
+**change the executor config once, no DAG changes needed.** Every task runs on
+the Spark cluster. Tasks that call `SparkSession.builder.getOrCreate()` get a
+live session for free — they are running inside a Spark driver process.
+
+## Architecture
+
+```
+Scheduler
+  └─► SparkStandaloneExecutor
+        └─► POST /v1/submissions/create   (Spark REST API on port 6066)
+              └─► Spark worker runs airflow_task_runner.py as driver
+                    └─► SparkSession available natively
+        └─► GET /v1/submissions/status/{id}  (polls until FINISHED/FAILED)
+```
+
+## Prerequisites
+
+- Docker + Docker Compose
+- Airflow with the `apache-airflow-providers-apache-spark` provider installed
+
+## Quick start
+
+### 1. Start the Spark cluster
+
+```bash
+cd dev/spark-standalone
+docker compose up -d
+```
+
+Verify the cluster is up:
+- Spark Master UI: http://localhost:8080
+- REST API: `curl http://localhost:6066/v1/submissions/status/test` should return JSON
+
+### 2. Configure Airflow
+
+Add to `airflow.cfg`:
+
+```ini
+[core]
+executor = airflow.providers.apache.spark.executors.spark_standalone_executor.SparkStandaloneExecutor
+
+[spark_standalone_executor]
+master_url            = spark://localhost:7077
+rest_url              = http://localhost:6066/v1/submissions
+task_runner_script    = file:///opt/airflow/scripts/airflow_task_runner.py
+spark_version         = 3.5.0
+driver_memory         = 512m
+executor_memory       = 1g
+executor_cores        = 1
+startup_timeout       = 30
+submission_timeout    = 30
+```
+
+### 3. Trigger the demo DAG
+
+```bash
+airflow dags trigger demo_spark_standalone_executor
+```
+
+Or through the Airflow UI.
+
+## Per-task Spark resource overrides
+
+Tasks can request additional resources via `executor_config`:
+
+```python
+@task(executor_config={"spark_properties": {"spark.executor.memory": "4g", "spark.executor.cores": "4"}})
+def heavy_job():
+    ...
+```
+
+## Limitations (POC scope)
+
+| Limitation | Status |
+|---|---|
+| Full Airflow task SDK integration | TODO — stub in `airflow_task_runner.py`. Blocked on [AIP-72 token propagation](https://github.com/apache/airflow/issues/45107) |
+| YARN / Kubernetes cluster managers | Not supported — use Livy or `SparkKubernetesExecutor` |
+| Task log streaming from Spark UI | Not implemented |
+| Callbacks (`on_failure_callback` etc.) | Not implemented |
+
+## Running the tests
+
+```bash
+uv run --project providers/apache/spark pytest \
+  providers/apache/spark/tests/unit/apache/spark/executors/test_spark_standalone_executor.py -xvs
+```

--- a/dev/spark-standalone/dags/demo_spark_jar_executor.py
+++ b/dev/spark-standalone/dags/demo_spark_jar_executor.py
@@ -1,0 +1,70 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+SparkStandaloneExecutor — Java JAR demo.
+
+Submits the built-in SparkPi example from the Spark distribution as a Java
+application using executor_config.  No SparkSubmitOperator, no new operator
+class — just a plain @task with a spark_jar hint.
+
+The executor skips AirflowDriverLauncher entirely and posts the JAR directly
+to the Spark REST Submission API.  Airflow maps driverState → task success/failure.
+
+Run with SparkStandaloneExecutor configured (see dev/spark-standalone/README.md).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from airflow.sdk import DAG, task
+
+# SparkPi ships with every Spark distribution under $SPARK_HOME/examples/jars/.
+# The filename encodes the Scala version and Spark version — glob it at runtime
+# or pin the exact name for your cluster.  For the spark:python3 base image
+# (Spark 4.0.x, Scala 2.13) the path below is correct.
+_SPARK_PI_JAR = "file:///opt/spark/examples/jars/spark-examples_2.13-4.0.1.jar"
+_SPARK_PI_CLASS = "org.apache.spark.examples.SparkPi"
+
+
+@task(executor_config={
+    "spark_jar": {
+        "app_resource": _SPARK_PI_JAR,
+        "main_class": _SPARK_PI_CLASS,
+        # Number of Monte Carlo partitions — higher = more accurate Pi estimate.
+        "app_args": ["100"],
+    }
+})
+def compute_pi() -> None:
+    """
+    Submits SparkPi as a Java application directly to the Spark cluster.
+
+    This function body is never executed — the executor intercepts the task,
+    sees spark_jar in executor_config, and submits the JAR to Spark REST API.
+    Airflow marks the task succeeded when Spark reports driverState=FINISHED.
+    """
+
+
+with DAG(
+    dag_id="spark_jar_demo",
+    start_date=datetime(2024, 1, 1),
+    schedule=None,
+    catchup=False,
+    tags=["spark", "poc", "java"],
+    doc_md=__doc__,
+):
+    compute_pi()

--- a/dev/spark-standalone/dags/demo_spark_standalone_executor.py
+++ b/dev/spark-standalone/dags/demo_spark_standalone_executor.py
@@ -1,0 +1,130 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+SparkStandaloneExecutor — demonstration DAG.
+
+This DAG exists to contrast the OLD approach (explicit SparkSubmitOperator per
+task) with the NEW approach (SparkStandaloneExecutor configured once, no DAG
+changes needed).
+
+OLD approach
+------------
+Every task that needs Spark must be an explicit operator::
+
+    from airflow.providers.apache.spark.operators.spark_submit import SparkSubmitOperator
+
+    heavy_transform = SparkSubmitOperator(
+        task_id="heavy_transform",
+        application="/path/to/heavy_transform.py",
+        conn_id="spark_default",
+        ...
+    )
+
+NEW approach (this DAG)
+-----------------------
+Configure ``executor = SparkStandaloneExecutor`` in airflow.cfg.  Every task
+is transparently submitted to the Spark cluster — no operator change needed.
+Tasks that use ``SparkSession`` get a live session for free.
+
+Running
+-------
+1. Start the Spark cluster:  ``cd dev/spark-standalone && docker compose up -d``
+2. Configure Airflow:
+
+   .. code-block:: ini
+
+       [core]
+       executor = airflow.providers.apache.spark.executors.spark_standalone_executor.SparkStandaloneExecutor
+
+       [spark_standalone_executor]
+       master_url = spark://localhost:7077
+       rest_url   = http://localhost:6066/v1/submissions
+
+3. Trigger the DAG from the Airflow UI or CLI.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from airflow.sdk import DAG, task
+
+# ---------------------------------------------------------------------------
+# Tasks
+# ---------------------------------------------------------------------------
+
+
+@task
+def ingest() -> dict:
+    """
+    Lightweight ingestion step — no Spark needed.
+
+    With SparkStandaloneExecutor this still runs on the Spark cluster (as a
+    driver process), but it does not request a SparkSession.
+    """
+    import os
+
+    running_on_spark = "SPARK_HOME" in os.environ or "SPARK_YARN_MODE" in os.environ
+    print(f"ingest: running_on_spark_worker={running_on_spark}")
+    return {"rows": 1_000_000, "source": "s3://bucket/raw/"}
+
+
+@task
+def heavy_transform(meta: dict) -> dict:
+    """
+    Spark-intensive transformation — uses SparkSession transparently.
+
+    No SparkSubmitOperator, no @task.pyspark decorator.  The SparkSession is
+    available because this task runs inside a Spark *driver* process when
+    SparkStandaloneExecutor is configured.
+    """
+
+    from pyspark.sql import SparkSession
+
+    spark = SparkSession.builder.appName("airflow-heavy-transform").getOrCreate()
+    print(f"Spark version: {spark.version}")
+    print(f"Application ID: {spark.sparkContext.applicationId}")
+
+    # Demonstrate distributed compute: sum over a large range
+    total = spark.range(meta["rows"]).selectExpr("sum(id) as s").collect()[0]["s"]
+    print(f"Sum of 0..{meta['rows']}: {total}")
+
+    spark.stop()
+    return {"total": total, "source": meta["source"]}
+
+
+@task
+def publish(result: dict) -> None:
+    """Final publish step — lightweight, no Spark needed."""
+    print(f"publish: writing result total={result['total']} from {result['source']}")
+
+
+# ---------------------------------------------------------------------------
+# DAG
+# ---------------------------------------------------------------------------
+
+with DAG(
+    dag_id="demo_spark_standalone_executor",
+    start_date=datetime(2024, 1, 1),
+    schedule=None,
+    catchup=False,
+    tags=["spark", "poc"],
+    doc_md=__doc__,
+) as dag:
+    meta = ingest()
+    result = heavy_transform(meta)
+    publish(result)

--- a/dev/spark-standalone/docker-compose.yml
+++ b/dev/spark-standalone/docker-compose.yml
@@ -1,0 +1,54 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Spark Standalone cluster for SparkStandaloneExecutor POC
+# Exposes the Spark Master REST API on port 6066 for task submission
+# and the Spark UI on port 8080.
+#
+# Uses a custom image (Dockerfile in this directory) that extends `spark:python3`
+# with apache-airflow-task-sdk installed — the same SDK that KubernetesExecutor
+# uses inside its pods to run real Airflow tasks.
+#
+# Build and start:  docker compose up --build -d
+
+version: "3.8"
+
+x-spark-worker: &spark-worker
+  build: .
+  depends_on:
+    - spark-master
+  # Run the worker process in the foreground (spark-class keeps it alive).
+  # -c 2 -m 2g: 2 cores and 2 GB RAM per worker.
+  command: /opt/spark/bin/spark-class org.apache.spark.deploy.worker.Worker spark://spark-master:7077 -c 2 -m 2g
+
+services:
+  spark-master:
+    build: .
+    # Run the master in the foreground and enable the REST Submission API (port 6066).
+    command: /opt/spark/bin/spark-class org.apache.spark.deploy.master.Master
+    environment:
+      - SPARK_MASTER_OPTS=-Dspark.master.rest.enabled=true -Dspark.master.rest.port=6066
+    ports:
+      - "7077:7077"   # Spark master (cluster comms)
+      - "6066:6066"   # REST Submission API
+      - "8080:8080"   # Spark Master UI
+
+  spark-worker-1:
+    <<: *spark-worker
+
+  spark-worker-2:
+    <<: *spark-worker

--- a/dev/spark-standalone/docker-compose.yml
+++ b/dev/spark-standalone/docker-compose.yml
@@ -19,6 +19,10 @@
 # Exposes the Spark Master REST API on port 6066 for task submission
 # and the Spark UI on port 8080.
 #
+# Also runs a MinIO instance (S3-compatible) for remote task log storage,
+# so the Airflow UI can read logs written by Spark driver processes without
+# needing a serve-logs daemon on each worker.
+#
 # Uses a custom image (Dockerfile in this directory) that extends `spark:python3`
 # with apache-airflow-task-sdk installed — the same SDK that KubernetesExecutor
 # uses inside its pods to run real Airflow tasks.
@@ -31,9 +35,15 @@ x-spark-worker: &spark-worker
   build: .
   depends_on:
     - spark-master
+    - minio
   # Run the worker process in the foreground (spark-class keeps it alive).
   # -c 2 -m 2g: 2 cores and 2 GB RAM per worker.
   command: /opt/spark/bin/spark-class org.apache.spark.deploy.worker.Worker spark://spark-master:7077 -c 2 -m 2g
+  volumes:
+    # Mount the host DAG files so the Airflow Task SDK can load task code.
+    # In production this would be git-sync or shared storage; for the POC we
+    # bind-mount the same directory Breeze reads from.
+    - ../../files/test_dags:/tmp/airflow/dags:ro
 
 services:
   spark-master:
@@ -52,3 +62,41 @@ services:
 
   spark-worker-2:
     <<: *spark-worker
+
+  # MinIO — S3-compatible object store for remote task log storage.
+  # Breeze (Airflow scheduler/API server) and Spark workers both reach it via
+  # host.docker.internal:9000.  The UI console is at http://localhost:9001.
+  minio:
+    image: minio/minio:latest
+    command: server /data --console-address ":9001"
+    environment:
+      - MINIO_ROOT_USER=minioadmin
+      - MINIO_ROOT_PASSWORD=minioadmin
+    ports:
+      - "9000:9000"   # S3 API
+      - "9001:9001"   # MinIO console UI
+    volumes:
+      - minio-data:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+
+  # One-shot service that creates the airflow-logs bucket on first start.
+  # Waits for MinIO to pass its healthcheck before running.
+  minio-init:
+    image: minio/mc:latest
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+        /usr/bin/mc alias set local http://minio:9000 minioadmin minioadmin &&
+        /usr/bin/mc mb --ignore-existing local/airflow-logs &&
+        echo 'Bucket airflow-logs ready.'
+      "
+
+volumes:
+  minio-data:

--- a/dev/spark-standalone/env.sh
+++ b/dev/spark-standalone/env.sh
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Source this file to configure Airflow to use SparkStandaloneExecutor:
+#
+#   source dev/spark-standalone/env.sh
+#
+# Then start the scheduler and API server normally:
+#
+#   airflow api-server &
+#   airflow scheduler
+
+# --- Core: switch executor ---
+export AIRFLOW__CORE__EXECUTOR=airflow.providers.apache.spark.executors.spark_standalone_executor.SparkStandaloneExecutor
+
+# --- Spark Standalone Executor config ---
+# REST API and master are reachable from the host via mapped ports.
+export AIRFLOW__SPARK_STANDALONE_EXECUTOR__REST_URL=http://localhost:6066/v1/submissions
+export AIRFLOW__SPARK_STANDALONE_EXECUTOR__MASTER_URL=spark://localhost:7077
+export AIRFLOW__SPARK_STANDALONE_EXECUTOR__TASK_RUNNER_SCRIPT=file:///opt/airflow/scripts/airflow_task_runner.py
+export AIRFLOW__SPARK_STANDALONE_EXECUTOR__SPARK_VERSION=4.0.1
+
+# --- Execution API: Spark drivers run inside Docker, so they reach the host via host.docker.internal ---
+# The Airflow API server must be started on port 8081 (default: 8080, may conflict with Spark UI).
+export AIRFLOW__API_SERVER__PORT=8081
+export AIRFLOW__EXECUTION_API__URL=http://host.docker.internal:8081/execution/
+
+echo "SparkStandaloneExecutor environment set."
+echo "  Spark master:  spark://localhost:7077"
+echo "  REST API:      http://localhost:6066"
+echo "  Airflow API:   http://host.docker.internal:8081/execution/ (as seen from Spark workers)"

--- a/dev/spark-standalone/env.sh
+++ b/dev/spark-standalone/env.sh
@@ -39,7 +39,34 @@ export AIRFLOW__SPARK_STANDALONE_EXECUTOR__SPARK_VERSION=4.0.1
 export AIRFLOW__API_SERVER__PORT=8081
 export AIRFLOW__EXECUTION_API__URL=http://host.docker.internal:8081/execution/
 
+# --- Remote logging: upload Spark driver logs to MinIO so they appear in the Airflow UI log tab ---
+# MinIO runs in the Spark docker-compose stack (docker compose up in dev/spark-standalone/).
+# The airflow-logs bucket is auto-created by the minio-init service on first start.
+export AIRFLOW__LOGGING__REMOTE_LOGGING=True
+export AIRFLOW__LOGGING__REMOTE_BASE_LOG_FOLDER=s3://airflow-logs/
+export AIRFLOW__LOGGING__REMOTE_LOG_CONN_ID=minio_logs
+# MinIO credentials (matches MINIO_ROOT_USER/MINIO_ROOT_PASSWORD in docker-compose.yml).
+# endpoint_url uses host.docker.internal so this connection works from both the Breeze
+# container and (if you ever run the scheduler on the host) directly.
+export AIRFLOW_CONN_MINIO_LOGS='aws://minioadmin:minioadmin@?endpoint_url=http%3A%2F%2Fhost.docker.internal%3A9000&region_name=us-east-1'
+
+# --- Spark master UI URL (used by the executor to look up worker log URLs) ---
+# host.docker.internal:8080 is the Spark master UI as seen from inside the Breeze container.
+export AIRFLOW__SPARK_STANDALONE_EXECUTOR__MASTER_UI_URL=http://host.docker.internal:8080
+
+# --- Network: connect the Breeze container to the Spark docker-compose network ---
+# The executor fetches driver logs directly from worker HTTP UIs (192.168.117.x:8081).
+# Those IPs are only routable from the Breeze container after this one-time network join.
+_BREEZE_CONTAINER=$(docker ps --filter 'name=breeze-airflow-run' --format '{{.Names}}' 2>/dev/null | head -1)
+if [ -n "$_BREEZE_CONTAINER" ]; then
+    docker network connect spark-standalone_default "$_BREEZE_CONTAINER" 2>/dev/null \
+        && echo "  Joined spark-standalone_default network (worker log fetch enabled)." \
+        || echo "  Already on spark-standalone_default network."
+fi
+unset _BREEZE_CONTAINER
+
 echo "SparkStandaloneExecutor environment set."
 echo "  Spark master:  spark://localhost:7077"
 echo "  REST API:      http://localhost:6066"
 echo "  Airflow API:   http://host.docker.internal:8081/execution/ (as seen from Spark workers)"
+echo "  Remote logs:   s3://airflow-logs/  (MinIO at localhost:9001)"

--- a/dev/spark-standalone/scripts/airflow_task_runner.py
+++ b/dev/spark-standalone/scripts/airflow_task_runner.py
@@ -1,0 +1,80 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+Airflow task runner entry point for SparkStandaloneExecutor.
+
+This script runs inside the Spark driver on the Spark cluster.
+It replicates exactly what the KubernetesExecutor does inside a Pod:
+
+    python -m airflow.sdk.execution_time.execute_workload --json-string <workload_json>
+
+The serialized ExecuteTask workload is passed via the AIRFLOW_EXECUTE_WORKLOAD
+environment variable, set by SparkStandaloneExecutor._build_env().
+
+The driver process runs on a Spark worker node, so SparkSession is available
+for free via SparkSession.builder.getOrCreate() — no SparkSubmitOperator needed.
+
+Requirements on the Spark worker image
+---------------------------------------
+- apache-airflow-task-sdk must be installed (provides execute_workload entry point)
+- Network access to the Airflow Execution API (AIRFLOW__EXECUTION_API__URL)
+
+See dev/spark-standalone/Dockerfile for a ready-made worker image.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s - %(message)s",
+    stream=sys.stdout,
+)
+log = logging.getLogger("airflow.task_runner")
+
+
+def main() -> None:
+    workload_json = os.environ.get("AIRFLOW_EXECUTE_WORKLOAD")
+    if not workload_json:
+        log.error("AIRFLOW_EXECUTE_WORKLOAD env var is not set — cannot run task")
+        sys.exit(1)
+
+    log.info("Airflow task runner starting inside Spark driver")
+
+    # SparkSession is available for free — this script runs inside a Spark driver.
+    # Tasks that call SparkSession.builder.getOrCreate() will receive this session.
+    try:
+        from pyspark.sql import SparkSession
+
+        spark = SparkSession.builder.getOrCreate()
+        log.info("SparkSession ready — version=%s app_id=%s", spark.version, spark.sparkContext.applicationId)
+    except ImportError:
+        log.warning("pyspark not available — running without SparkSession")
+
+    # Invoke the Airflow task SDK — identical to what KubernetesExecutor does:
+    #   python -m airflow.sdk.execution_time.execute_workload --json-string <json>
+    from airflow.sdk.execution_time.execute_workload import main as execute_workload
+
+    sys.argv = ["execute_workload", "--json-string", workload_json]
+    execute_workload()
+
+
+if __name__ == "__main__":
+    main()

--- a/providers/apache/spark/provider.yaml
+++ b/providers/apache/spark/provider.yaml
@@ -207,3 +207,6 @@ connection-types:
 task-decorators:
   - class-name: airflow.providers.apache.spark.decorators.pyspark.pyspark_task
     name: pyspark
+
+executors:
+  - airflow.providers.apache.spark.executors.spark_standalone_executor.SparkStandaloneExecutor

--- a/providers/apache/spark/pyproject.toml
+++ b/providers/apache/spark/pyproject.toml
@@ -63,6 +63,7 @@ dependencies = [
     "apache-airflow-providers-common-compat>=1.12.0",
     "pyspark-client>=4.0.0",
     "grpcio-status>=1.67.0",
+    "requests>=2.27.0",
 ]
 
 # The optional dependencies should be modified in place in the generated file

--- a/providers/apache/spark/src/airflow/providers/apache/spark/executors/__init__.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/executors/__init__.py
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations

--- a/providers/apache/spark/src/airflow/providers/apache/spark/executors/spark_standalone_executor.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/executors/spark_standalone_executor.py
@@ -84,6 +84,12 @@ Configuration  (airflow.cfg)
 
     # Seconds to wait for each submission request
     submission_timeout = 30
+
+    # Base URL of the Spark master HTTP UI (not the REST submission port).
+    # Used to look up which worker ran a given driver and to retrieve its
+    # log URL.  Required for JAR task log upload to the Airflow remote log
+    # store.  Defaults to http://localhost:8080.
+    master_ui_url = http://localhost:8080
 """
 
 from __future__ import annotations
@@ -127,6 +133,7 @@ class SparkStandaloneExecutor(BaseExecutor):
         super().__init__(parallelism=parallelism)
         self._rest_url: str = ""
         self._master_url: str = ""
+        self._master_ui_url: str = ""
         self._task_runner_script: str = ""
         self._driver_launcher_jar: str = ""
         self._spark_version: str = "3.5.0"
@@ -165,6 +172,9 @@ class SparkStandaloneExecutor(BaseExecutor):
         self._executor_memory = conf.get("spark_standalone_executor", "executor_memory", fallback="1g")
         self._executor_cores = conf.get("spark_standalone_executor", "executor_cores", fallback="1")
         self._submission_timeout = conf.getint("spark_standalone_executor", "submission_timeout", fallback=30)
+        self._master_ui_url = conf.get(
+            "spark_standalone_executor", "master_ui_url", fallback="http://localhost:8080"
+        )
         startup_timeout = conf.getint("spark_standalone_executor", "startup_timeout", fallback=30)
 
         self._validate_connectivity(startup_timeout)
@@ -214,12 +224,14 @@ class SparkStandaloneExecutor(BaseExecutor):
 
             if driver_state == _DRIVER_STATE_SUCCESS:
                 self.log.info("Task %s finished successfully (submissionId=%s)", key, submission_id)
+                self._upload_driver_logs(key, submission_id)
                 self.success(key)
                 del self._submissions[key]
             elif driver_state in _DRIVER_STATE_TERMINAL_FAILURE:
                 self.log.error(
                     "Task %s failed — driverState=%s (submissionId=%s)", key, driver_state, submission_id
                 )
+                self._upload_driver_logs(key, submission_id)
                 self.fail(key, info=f"driverState={driver_state}")
                 del self._submissions[key]
             else:
@@ -408,6 +420,191 @@ class SparkStandaloneExecutor(BaseExecutor):
                 env[key] = val
 
         return env
+
+    def _upload_driver_logs(self, key: TaskInstanceKey, submission_id: str) -> None:
+        """
+        Fetch Spark driver stdout/stderr and upload to the Airflow remote log store.
+
+        When ``AIRFLOW__LOGGING__REMOTE_BASE_LOG_FOLDER`` is set (e.g.
+        ``s3://airflow-logs/``), the driver logs are fetched from the Spark
+        worker HTTP UI and uploaded to the same S3/MinIO path the Airflow log
+        tab reads from, so JAR task logs appear inline with Python task logs.
+
+        Silently no-ops if:
+        - remote logging is not configured
+        - the Spark master UI or worker UI is unreachable
+        - ``apache-airflow-providers-amazon`` is not installed
+
+        The Breeze container (or the host running the scheduler) must be able
+        to reach the worker HTTP UI.  In the Docker Compose dev setup this
+        requires connecting the Airflow container to the Spark network once::
+
+            docker network connect spark-standalone_default <airflow-container>
+
+        (``dev/spark-standalone/env.sh`` does this automatically.)
+        """
+        try:
+            self._do_upload_driver_logs(key, submission_id)
+        except Exception as exc:
+            self.log.warning(
+                "Could not upload driver logs for %s (submissionId=%s): %s  "
+                "Logs are still available in the Spark UI.",
+                key,
+                submission_id,
+                exc,
+            )
+
+    def _do_upload_driver_logs(self, key: TaskInstanceKey, submission_id: str) -> None:
+        import os
+
+        from airflow.configuration import conf as airflow_conf
+
+        remote_base = os.environ.get("AIRFLOW__LOGGING__REMOTE_BASE_LOG_FOLDER") or airflow_conf.get(
+            "logging", "remote_base_log_folder", fallback=""
+        )
+        if not remote_base:
+            return
+
+        worker_ui_url = self._get_worker_ui_url(submission_id)
+        if not worker_ui_url:
+            self.log.debug(
+                "Could not determine worker UI URL for submissionId=%s; skipping log upload.",
+                submission_id,
+            )
+            return
+
+        content = self._fetch_driver_log_content(worker_ui_url, submission_id)
+        if not content:
+            return
+
+        log_relative_path = (
+            f"dag_id={key.dag_id}/run_id={key.run_id}/task_id={key.task_id}/attempt={key.try_number}.log"
+        )
+        self._write_log_to_remote(remote_base, log_relative_path, content)
+        self.log.info("Driver logs for task %s uploaded to %s", key, remote_base)
+
+    def _get_worker_ui_url(self, submission_id: str) -> str | None:
+        """
+        Return the Spark worker HTTP UI base URL that ran the given submission.
+
+        Queries the Spark master JSON API (``{master_ui_url}/json/``) to look
+        up the worker's ``webuiaddress`` by matching ``workerHostPort`` from
+        the driver status response.
+        """
+        # Find which worker ran the driver.
+        try:
+            status = requests.get(f"{self._rest_url}/status/{submission_id}", timeout=10).json()
+        except (ConnectionError, RequestException) as exc:
+            self.log.debug("Could not fetch driver status for log lookup: %s", exc)
+            return None
+
+        worker_host_port = status.get("workerHostPort", "")
+        if not worker_host_port:
+            return None
+        worker_host = worker_host_port.split(":")[0]
+
+        # Look up the worker's HTTP UI address from the master.
+        try:
+            master_json = requests.get(f"{self._master_ui_url}/json/", timeout=10).json()
+        except (ConnectionError, RequestException) as exc:
+            self.log.debug("Could not reach Spark master UI at %s: %s", self._master_ui_url, exc)
+            return None
+
+        for worker in master_json.get("workers", []):
+            if worker.get("host") == worker_host:
+                return worker.get("webuiaddress")
+
+        self.log.debug(
+            "Worker with host %s not found in master JSON (submission %s).", worker_host, submission_id
+        )
+        return None
+
+    def _fetch_driver_log_content(self, worker_ui_url: str, submission_id: str) -> str:
+        """
+        Fetch driver stderr and stdout from the Spark worker ``/log/`` endpoint.
+
+        The endpoint returns a one-line header followed by the raw log bytes::
+
+            ==== Bytes 0-12345 of 12345 of /opt/spark/work/driver-xxx/stdout ====
+            Pi is roughly 3.14...
+
+        stderr is included first (full Spark execution log) then stdout.
+        """
+        parts = []
+        for log_type in ("stderr", "stdout"):
+            try:
+                resp = requests.get(
+                    f"{worker_ui_url.rstrip('/')}/log/",
+                    params={
+                        "driverId": submission_id,
+                        "logType": log_type,
+                        "offset": "0",
+                        "byteLength": "10485760",  # 10 MiB cap
+                    },
+                    timeout=60,
+                )
+                if resp.ok:
+                    # Strip the "==== Bytes ... ====" header line
+                    lines = resp.text.splitlines(keepends=True)
+                    body = "".join(lines[1:]) if lines else ""
+                    if body.strip():
+                        parts.append(f"=== Spark driver {log_type} ===\n{body}")
+                else:
+                    self.log.debug(
+                        "Worker %s returned HTTP %s for %s %s log",
+                        worker_ui_url,
+                        resp.status_code,
+                        submission_id,
+                        log_type,
+                    )
+            except (ConnectionError, RequestException) as exc:
+                self.log.debug("Could not fetch %s log for %s: %s", log_type, submission_id, exc)
+
+        return "\n".join(parts)
+
+    def _write_log_to_remote(self, remote_base: str, log_relative_path: str, content: str) -> None:
+        """
+        Upload *content* to ``remote_base/log_relative_path``.
+
+        Only S3/S3A remote log folders are supported.  The upload uses
+        ``S3Hook`` from ``apache-airflow-providers-amazon`` which must be
+        installed separately (it is **not** a hard dependency of this
+        provider).  On MinIO the connection must have ``endpoint_url`` set in
+        its extras (``{"endpoint_url": "http://minio:9000"}``).
+        """
+        import os
+        from urllib.parse import urlparse
+
+        from airflow.configuration import conf as airflow_conf
+
+        parsed = urlparse(remote_base)
+        if parsed.scheme not in ("s3", "s3a"):
+            self.log.debug(
+                "Remote log scheme %r is not supported for JAR task log upload "
+                "(only s3:// / s3a:// are supported).",
+                parsed.scheme,
+            )
+            return
+
+        conn_id = os.environ.get("AIRFLOW__LOGGING__REMOTE_LOG_CONN_ID") or airflow_conf.get(
+            "logging", "remote_log_conn_id", fallback="aws_default"
+        )
+
+        bucket = parsed.netloc
+        key_prefix = parsed.path.strip("/")
+        s3_key = f"{key_prefix}/{log_relative_path}" if key_prefix else log_relative_path
+
+        try:
+            from airflow.providers.amazon.aws.hooks.s3 import S3Hook  # type: ignore[import]
+        except ImportError:
+            self.log.warning(
+                "apache-airflow-providers-amazon is not installed; "
+                "cannot upload Spark driver logs to S3/MinIO.  "
+                "Install it with: pip install apache-airflow-providers-amazon"
+            )
+            return
+
+        S3Hook(aws_conn_id=conn_id).load_string(content, key=s3_key, bucket_name=bucket, replace=True)
 
     def _get_driver_state(self, submission_id: str) -> str:
         """

--- a/providers/apache/spark/src/airflow/providers/apache/spark/executors/spark_standalone_executor.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/executors/spark_standalone_executor.py
@@ -1,0 +1,331 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""
+SparkStandaloneExecutor — submits Airflow tasks to a Spark Standalone cluster.
+
+Motivation
+----------
+The ``SparkSubmitOperator`` (and ``SparkKubernetesOperator``) require every
+task that should run on Spark to be explicitly declared as a Spark operator in
+the DAG.  This mirrors the ``KubernetesPodOperator`` story before
+``KubernetesExecutor`` existed.
+
+``SparkStandaloneExecutor`` solves the same problem for Spark Standalone
+clusters: configure the executor once, and every Airflow task is transparently
+submitted to the Spark cluster without any DAG-level changes.  Tasks that use
+``SparkSession`` obtain a live session for free because they run inside a Spark
+*driver* process on the cluster.
+
+Architecture
+------------
+::
+
+    Scheduler
+      │
+      └─► SparkStandaloneExecutor._process_workloads()
+            │
+            └─► POST /v1/submissions/create   (Spark REST Submission API)
+                  │
+                  Spark master creates a driver process on a worker node
+                  │
+                  Driver runs dev/spark-standalone/scripts/airflow_task_runner.py
+                  │  (which calls the Airflow task SDK — full impl: TODO AIP-72)
+                  │
+            SparkStandaloneExecutor.sync()
+            └─► GET /v1/submissions/status/{id}
+                  │
+                  Maps driverState → TaskInstanceState
+                  │
+      Scheduler: task succeeded / failed
+
+Configuration  (airflow.cfg)
+----------------------------
+.. code-block:: ini
+
+    [spark_standalone_executor]
+    # Spark master URL used inside submitted jobs
+    master_url = spark://localhost:7077
+
+    # Base URL of the Spark REST Submission API
+    rest_url = http://localhost:6066/v1/submissions
+
+    # Path to the Python task runner script on the Spark worker nodes
+    task_runner_script = /opt/airflow/scripts/airflow_task_runner.py
+
+    # Path to the JVM launcher JAR on the Spark worker nodes.
+    # Spark Standalone cluster mode does not support Python appResource;
+    # this JAR is the real appResource — it spawns python3 as a subprocess.
+    driver_launcher_jar = file:///opt/airflow/jars/airflow-driver-launcher.jar
+
+    # Spark version reported to the REST API (must match the cluster)
+    spark_version = 3.5.0
+
+    # Per-task resource defaults (can be overridden via executor_config)
+    driver_memory   = 512m
+    executor_memory = 1g
+    executor_cores  = 1
+
+    # Seconds to wait for the REST API during start()
+    startup_timeout = 30
+
+    # Seconds to wait for each submission request
+    submission_timeout = 30
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import requests
+from requests.exceptions import ConnectionError, RequestException
+
+from airflow.executors.base_executor import PARALLELISM, BaseExecutor
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from airflow.executors import workloads
+    from airflow.models.taskinstancekey import TaskInstanceKey
+
+log = logging.getLogger(__name__)
+
+# Driver states returned by the Spark REST Submission API.
+_DRIVER_STATE_SUCCESS = "FINISHED"
+_DRIVER_STATE_TERMINAL_FAILURE = frozenset({"FAILED", "KILLED", "ERROR", "UNKNOWN"})
+_DRIVER_STATE_IN_PROGRESS = frozenset({"SUBMITTED", "RUNNING", "RELAUNCHING"})
+
+
+class SparkStandaloneExecutor(BaseExecutor):
+    """
+    Execute Airflow tasks on a Spark Standalone cluster via the REST Submission API.
+
+    Each task is submitted as a Spark *driver* application (cluster deploy mode).
+    The driver runs ``airflow_task_runner.py`` on a Spark worker node; tasks that
+    call ``SparkSession.builder.getOrCreate()`` receive a live session because they
+    are already inside a Spark driver process.
+
+    This is the Spark analogue of ``KubernetesExecutor``: changing the executor
+    in ``airflow.cfg`` is sufficient — no ``SparkSubmitOperator`` needed in DAGs.
+    """
+
+    def __init__(self, parallelism: int = PARALLELISM) -> None:
+        super().__init__(parallelism=parallelism)
+        self._rest_url: str = ""
+        self._master_url: str = ""
+        self._task_runner_script: str = ""
+        self._driver_launcher_jar: str = ""
+        self._spark_version: str = "3.5.0"
+        self._driver_memory: str = "512m"
+        self._executor_memory: str = "1g"
+        self._executor_cores: str = "1"
+        self._submission_timeout: int = 30
+        # Maps TaskInstanceKey → Spark submissionId for in-flight tasks.
+        self._submissions: dict[TaskInstanceKey, str] = {}
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        from airflow.configuration import conf
+
+        self._rest_url = conf.get(
+            "spark_standalone_executor", "rest_url", fallback="http://localhost:6066/v1/submissions"
+        )
+        self._master_url = conf.get(
+            "spark_standalone_executor", "master_url", fallback="spark://localhost:7077"
+        )
+        self._task_runner_script = conf.get(
+            "spark_standalone_executor",
+            "task_runner_script",
+            fallback="/opt/airflow/scripts/airflow_task_runner.py",
+        )
+        self._driver_launcher_jar = conf.get(
+            "spark_standalone_executor",
+            "driver_launcher_jar",
+            fallback="file:///opt/airflow/jars/airflow-driver-launcher.jar",
+        )
+        self._spark_version = conf.get("spark_standalone_executor", "spark_version", fallback="3.5.0")
+        self._driver_memory = conf.get("spark_standalone_executor", "driver_memory", fallback="512m")
+        self._executor_memory = conf.get("spark_standalone_executor", "executor_memory", fallback="1g")
+        self._executor_cores = conf.get("spark_standalone_executor", "executor_cores", fallback="1")
+        self._submission_timeout = conf.getint("spark_standalone_executor", "submission_timeout", fallback=30)
+        startup_timeout = conf.getint("spark_standalone_executor", "startup_timeout", fallback=30)
+
+        self._validate_connectivity(startup_timeout)
+        self.log.info("SparkStandaloneExecutor started — master=%s rest=%s", self._master_url, self._rest_url)
+
+    def end(self) -> None:
+        self._kill_all_submissions()
+
+    def terminate(self) -> None:
+        self._kill_all_submissions()
+
+    # ------------------------------------------------------------------
+    # Workload dispatch
+    # ------------------------------------------------------------------
+
+    def _process_workloads(self, workload_list: Sequence[workloads.All]) -> None:
+        from airflow.executors.workloads import ExecuteTask
+
+        for workload in workload_list:
+            if not isinstance(workload, ExecuteTask):
+                raise RuntimeError(
+                    f"{type(self).__name__} only handles ExecuteTask workloads, got {type(workload)}"
+                )
+
+            key = workload.ti.key
+            del self.queued_tasks[key]
+
+            submission_id = self._submit(workload)
+            if submission_id:
+                self._submissions[key] = submission_id
+                self.running.add(key)
+                self.log.info("Task %s submitted to Spark — submissionId=%s", key, submission_id)
+            else:
+                self.fail(key, info="Spark submission failed")
+
+    # ------------------------------------------------------------------
+    # Sync (poll running submissions)
+    # ------------------------------------------------------------------
+
+    def sync(self) -> None:
+        for key, submission_id in list(self._submissions.items()):
+            try:
+                driver_state = self._get_driver_state(submission_id)
+            except RequestException as exc:
+                self.log.warning("Could not fetch status for %s (%s): %s", key, submission_id, exc)
+                continue
+
+            if driver_state == _DRIVER_STATE_SUCCESS:
+                self.log.info("Task %s finished successfully (submissionId=%s)", key, submission_id)
+                self.success(key)
+                del self._submissions[key]
+            elif driver_state in _DRIVER_STATE_TERMINAL_FAILURE:
+                self.log.error(
+                    "Task %s failed — driverState=%s (submissionId=%s)", key, driver_state, submission_id
+                )
+                self.fail(key, info=f"driverState={driver_state}")
+                del self._submissions[key]
+            else:
+                self.log.debug("Task %s in progress — driverState=%s", key, driver_state)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _submit(self, workload: Any) -> str | None:
+        """Submit a task to the Spark cluster. Returns the submissionId or None on failure."""
+        ti = workload.ti
+        payload: dict[str, Any] = {
+            "action": "CreateSubmissionRequest",
+            "clientSparkVersion": self._spark_version,
+            # Spark Standalone cluster mode does not support Python appResource.
+            # We submit a thin JVM shim (AirflowDriverLauncher) that spawns
+            # python3 as a subprocess, inheriting AIRFLOW_EXECUTE_WORKLOAD.
+            "appResource": self._driver_launcher_jar,
+            "mainClass": "AirflowDriverLauncher",
+            "appArgs": [],
+            "sparkProperties": {
+                "spark.master": self._master_url,
+                "spark.submit.deployMode": "cluster",
+                "spark.app.name": f"airflow-{ti.dag_id}-{ti.task_id}-{ti.run_id[:8]}",
+                "spark.driver.memory": self._driver_memory,
+                "spark.executor.memory": self._executor_memory,
+                "spark.executor.cores": self._executor_cores,
+            },
+            "environmentVariables": self._build_env(workload),
+        }
+
+        # Allow per-task overrides via executor_config
+        if ti.executor_config:
+            spark_props = ti.executor_config.get("spark_properties", {})
+            payload["sparkProperties"].update(spark_props)
+
+        try:
+            resp = requests.post(
+                f"{self._rest_url}/create",
+                json=payload,
+                timeout=self._submission_timeout,
+            )
+            if not resp.ok:
+                self.log.error("Spark REST API returned %s for %s: %s", resp.status_code, ti.key, resp.text)
+                return None
+            data = resp.json()
+            if data.get("success"):
+                return data["submissionId"]
+            self.log.error("Spark rejected submission for %s: %s", ti.key, data)
+            return None
+        except (ConnectionError, RequestException) as exc:
+            self.log.error("Failed to submit task %s to Spark REST API: %s", ti.key, exc)
+            return None
+
+    def _build_env(self, workload: Any) -> dict[str, str]:
+        """Build the environment variables dict injected into the Spark driver process."""
+        from airflow.configuration import conf
+
+        # Serialize the full workload as JSON — identical to what KubernetesExecutor passes
+        # to the pod via `python -m airflow.sdk.execution_time.execute_workload --json-string`.
+        env: dict[str, str] = {
+            "AIRFLOW_EXECUTE_WORKLOAD": workload.model_dump_json(),
+            # Script path for AirflowDriverLauncher (the JVM shim) to invoke.
+            "AIRFLOW_TASK_RUNNER_SCRIPT": self._task_runner_script,
+            # Spark worker images may run as a system user with HOME=/nonexistent.
+            # Airflow's logging init tries to mkdir under HOME, so point it somewhere writable.
+            "HOME": "/tmp",
+        }
+
+        # Execution API URL so the task runner can communicate back to Airflow.
+        execution_api_url = conf.get("execution_api", "url", fallback="")
+        if execution_api_url:
+            env["AIRFLOW__EXECUTION_API__URL"] = execution_api_url
+
+        return env
+
+    def _get_driver_state(self, submission_id: str) -> str:
+        """Return the driverState string for the given submission."""
+        resp = requests.get(
+            f"{self._rest_url}/status/{submission_id}",
+            timeout=10,
+        )
+        resp.raise_for_status()
+        return resp.json()["driverState"]
+
+    def _kill_all_submissions(self) -> None:
+        for key, submission_id in list(self._submissions.items()):
+            try:
+                requests.post(f"{self._rest_url}/kill/{submission_id}", timeout=10)
+                self.log.info("Killed Spark submission %s for task %s", submission_id, key)
+            except RequestException as exc:
+                self.log.warning("Failed to kill submission %s: %s", submission_id, exc)
+        self._submissions.clear()
+
+    def _validate_connectivity(self, timeout: int) -> None:
+        """Probe the REST API to fail fast if the Spark master is unreachable."""
+        probe_url = f"{self._rest_url}/status/probe"
+        try:
+            # A 404 is expected (no such submission) — we just want an HTTP response.
+            requests.get(probe_url, timeout=timeout)
+            self.log.debug("Spark REST API reachable at %s", self._rest_url)
+        except ConnectionError as exc:
+            raise RuntimeError(
+                f"SparkStandaloneExecutor cannot reach Spark REST API at {self._rest_url!r}. "
+                "Ensure the Spark master is running with REST enabled "
+                "(SPARK_MASTER_REST_ENABLED=true or spark.master.rest.enabled=true). "
+                f"Original error: {exc}"
+            ) from exc

--- a/providers/apache/spark/src/airflow/providers/apache/spark/executors/spark_standalone_executor.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/executors/spark_standalone_executor.py
@@ -232,6 +232,14 @@ class SparkStandaloneExecutor(BaseExecutor):
     def _submit(self, workload: Any) -> str | None:
         """Submit a task to the Spark cluster. Returns the submissionId or None on failure."""
         ti = workload.ti
+        spark_jar = (ti.executor_config or {}).get("spark_jar")
+        if spark_jar:
+            return self._submit_jar(spark_jar, ti)
+        return self._submit_python_task(workload)
+
+    def _submit_python_task(self, workload: Any) -> str | None:
+        """Submit a Python Airflow task via AirflowDriverLauncher."""
+        ti = workload.ti
         payload: dict[str, Any] = {
             "action": "CreateSubmissionRequest",
             "clientSparkVersion": self._spark_version,
@@ -252,11 +260,83 @@ class SparkStandaloneExecutor(BaseExecutor):
             "environmentVariables": self._build_env(workload),
         }
 
-        # Allow per-task overrides via executor_config
+        # Allow per-task resource overrides via executor_config
         if ti.executor_config:
             spark_props = ti.executor_config.get("spark_properties", {})
             payload["sparkProperties"].update(spark_props)
 
+        return self._post_submission(payload, ti)
+
+    def _submit_jar(self, spark_jar: dict[str, Any], ti: Any) -> str | None:
+        """
+        Submit a JVM application directly to the Spark cluster.
+
+        Used when ``executor_config`` contains a ``spark_jar`` dict::
+
+            @task(
+                executor_config={
+                    "spark_jar": {
+                        "app_resource": "file:///opt/myapp/my-job.jar",
+                        "main_class": "com.example.MyJob",
+                        "app_args": ["--input", "s3://raw/"],
+                        # spark_properties is optional — use only for per-task overrides.
+                    }
+                }
+            )
+            def run_job():
+                pass  # body is not executed
+
+        No ``AirflowDriverLauncher`` or Task SDK involvement — Airflow treats the
+        job as a black box and maps driverState to task success/failure.
+
+        Infrastructure defaults (master URL, memory, classpath) are derived from
+        executor config so DAG authors only need to specify what to run, not how.
+        ``spark_properties`` overrides are applied last and take full precedence.
+        """
+        app_resource = spark_jar["app_resource"]
+
+        spark_props: dict[str, Any] = {
+            "spark.master": self._master_url,
+            "spark.submit.deployMode": "cluster",
+            "spark.app.name": f"airflow-{ti.dag_id}-{ti.task_id}-{ti.run_id[:8]}",
+            "spark.driver.memory": self._driver_memory,
+            "spark.executor.memory": self._executor_memory,
+            "spark.executor.cores": self._executor_cores,
+        }
+
+        # Spark's DriverWrapper loads the user JAR via a dynamic URLClassLoader,
+        # not the JVM system classloader.  Scala/Java lambdas serialized from that
+        # child classloader cannot be deserialized on executors because
+        # LambdaMetafactory requires the implementation class in the system
+        # classloader on both sides.  Adding the JAR to extraClassPath on both
+        # driver and executor puts it in the system classloader, fixing the
+        # SerializedLambda ClassCastException that otherwise occurs at runtime.
+        #
+        # For remote URIs (s3://, hdfs://, http://) Spark's own file-serving
+        # mechanism handles distribution via spark.jars instead.
+        if app_resource.startswith("file://"):
+            local_path = app_resource[len("file://") :]
+            spark_props["spark.driver.extraClassPath"] = local_path
+            spark_props["spark.executor.extraClassPath"] = local_path
+        else:
+            spark_props["spark.jars"] = app_resource
+
+        # User-provided overrides are applied last and always win.
+        spark_props.update(spark_jar.get("spark_properties", {}))
+
+        payload: dict[str, Any] = {
+            "action": "CreateSubmissionRequest",
+            "clientSparkVersion": self._spark_version,
+            "appResource": app_resource,
+            "mainClass": spark_jar["main_class"],
+            "appArgs": spark_jar.get("app_args", []),
+            "sparkProperties": spark_props,
+            "environmentVariables": {},
+        }
+        return self._post_submission(payload, ti)
+
+    def _post_submission(self, payload: dict[str, Any], ti: Any) -> str | None:
+        """POST a submission payload to the Spark REST API. Returns submissionId or None."""
         try:
             resp = requests.post(
                 f"{self._rest_url}/create",

--- a/providers/apache/spark/src/airflow/providers/apache/spark/executors/spark_standalone_executor.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/executors/spark_standalone_executor.py
@@ -277,8 +277,6 @@ class SparkStandaloneExecutor(BaseExecutor):
 
     def _build_env(self, workload: Any) -> dict[str, str]:
         """Build the environment variables dict injected into the Spark driver process."""
-        from airflow.configuration import conf
-
         # Serialize the full workload as JSON — identical to what KubernetesExecutor passes
         # to the pod via `python -m airflow.sdk.execution_time.execute_workload --json-string`.
         env: dict[str, str] = {
@@ -286,25 +284,73 @@ class SparkStandaloneExecutor(BaseExecutor):
             # Script path for AirflowDriverLauncher (the JVM shim) to invoke.
             "AIRFLOW_TASK_RUNNER_SCRIPT": self._task_runner_script,
             # Spark worker images may run as a system user with HOME=/nonexistent.
-            # Airflow's logging init tries to mkdir under HOME, so point it somewhere writable.
+            # Airflow's logging init tries to mkdir under $HOME/airflow/logs; use a
+            # path that doesn't collide with any volume mounts under /tmp/airflow.
             "HOME": "/tmp",
+            "AIRFLOW__LOGGING__BASE_LOG_FOLDER": "/tmp/airflow-driver-logs",
         }
 
+        import os
+
         # Execution API URL so the task runner can communicate back to Airflow.
-        execution_api_url = conf.get("execution_api", "url", fallback="")
+        # The Task SDK reads AIRFLOW__CORE__EXECUTION_API_SERVER_URL via
+        # conf.get("core", "execution_api_server_url"). Read from os.environ
+        # directly so we pick it up regardless of which env var the operator set.
+        execution_api_url = os.environ.get("AIRFLOW__CORE__EXECUTION_API_SERVER_URL") or os.environ.get(
+            "AIRFLOW__EXECUTION_API__URL"
+        )
         if execution_api_url:
-            env["AIRFLOW__EXECUTION_API__URL"] = execution_api_url
+            env["AIRFLOW__CORE__EXECUTION_API_SERVER_URL"] = execution_api_url
+
+        # Ensure pip-installed packages (pyspark, airflow-sdk) are importable inside
+        # the python3 subprocess spawned by AirflowDriverLauncher.  The Spark Worker
+        # starts the driver JVM with a minimal environment (SPARK_HOME + PATH only),
+        # so site.py may not resolve /usr/local/lib/python3.10/dist-packages unless
+        # PYTHONPATH is set explicitly.  Preserve any existing value from the image.
+        if "PYTHONPATH" not in env:
+            env["PYTHONPATH"] = "/usr/local/lib/python3.10/dist-packages:/opt/spark/python"
+
+        # Propagate remote-logging configuration so Spark driver processes upload
+        # task logs to the same remote store (e.g. MinIO) that the Airflow UI reads.
+        for key in (
+            "AIRFLOW__LOGGING__REMOTE_LOGGING",
+            "AIRFLOW__LOGGING__REMOTE_BASE_LOG_FOLDER",
+            "AIRFLOW__LOGGING__REMOTE_LOG_CONN_ID",
+        ):
+            val = os.environ.get(key)
+            if val:
+                env[key] = val
+
+        # Propagate any AIRFLOW_CONN_* env vars so the remote logging connection
+        # (e.g. minio_logs) is available inside the driver process.
+        for key, val in os.environ.items():
+            if key.startswith("AIRFLOW_CONN_"):
+                env[key] = val
 
         return env
 
     def _get_driver_state(self, submission_id: str) -> str:
-        """Return the driverState string for the given submission."""
+        """
+        Return the driverState string for the given submission.
+
+        When Spark cannot find the submission (master restarted, driver cleaned
+        up after completion, etc.) it returns a response with ``success=false``
+        and no ``driverState`` key.  Fall back to ``"UNKNOWN"`` in that case,
+        which is already mapped to terminal failure.
+        """
         resp = requests.get(
             f"{self._rest_url}/status/{submission_id}",
             timeout=10,
         )
         resp.raise_for_status()
-        return resp.json()["driverState"]
+        data = resp.json()
+        if "driverState" not in data:
+            self.log.warning(
+                "Spark REST API response for %s has no driverState — treating as UNKNOWN. Response: %s",
+                submission_id,
+                data,
+            )
+        return data.get("driverState", "UNKNOWN")
 
     def _kill_all_submissions(self) -> None:
         for key, submission_id in list(self._submissions.items()):

--- a/providers/apache/spark/src/airflow/providers/apache/spark/get_provider_info.py
+++ b/providers/apache/spark/src/airflow/providers/apache/spark/get_provider_info.py
@@ -131,4 +131,7 @@ def get_provider_info():
                 "name": "pyspark",
             }
         ],
+        "executors": [
+            "airflow.providers.apache.spark.executors.spark_standalone_executor.SparkStandaloneExecutor"
+        ],
     }

--- a/providers/apache/spark/tests/unit/apache/spark/executors/__init__.py
+++ b/providers/apache/spark/tests/unit/apache/spark/executors/__init__.py
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations

--- a/providers/apache/spark/tests/unit/apache/spark/executors/test_spark_standalone_executor.py
+++ b/providers/apache/spark/tests/unit/apache/spark/executors/test_spark_standalone_executor.py
@@ -133,6 +133,181 @@ class TestSparkStandaloneExecutorSubmit:
         assert props["spark.executor.memory"] == "4g"
 
 
+class TestSparkStandaloneExecutorJarSubmit:
+    def test_jar_submit_uses_app_resource_and_main_class(self, executor):
+        workload = _make_workload()
+        workload.ti.executor_config = {
+            "spark_jar": {
+                "app_resource": "s3://bucket/my-job.jar",
+                "main_class": "com.example.MyJob",
+            }
+        }
+        mock_resp = MagicMock()
+        mock_resp.ok = True
+        mock_resp.json.return_value = {"success": True, "submissionId": "driver-jar-001"}
+
+        with patch("requests.post", return_value=mock_resp) as mock_post:
+            submission_id = executor._submit(workload)
+
+        assert submission_id == "driver-jar-001"
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["appResource"] == "s3://bucket/my-job.jar"
+        assert payload["mainClass"] == "com.example.MyJob"
+
+    def test_jar_submit_does_not_use_driver_launcher(self, executor):
+        workload = _make_workload()
+        workload.ti.executor_config = {
+            "spark_jar": {
+                "app_resource": "s3://bucket/my-job.jar",
+                "main_class": "com.example.MyJob",
+            }
+        }
+        mock_resp = MagicMock()
+        mock_resp.ok = True
+        mock_resp.json.return_value = {"success": True, "submissionId": "driver-jar-002"}
+
+        with patch("requests.post", return_value=mock_resp) as mock_post:
+            executor._submit(workload)
+
+        payload = mock_post.call_args.kwargs["json"]
+        assert "AirflowDriverLauncher" not in payload["appResource"]
+        assert payload["mainClass"] != "AirflowDriverLauncher"
+        assert payload["environmentVariables"] == {}
+
+    def test_jar_submit_passes_app_args(self, executor):
+        workload = _make_workload()
+        workload.ti.executor_config = {
+            "spark_jar": {
+                "app_resource": "s3://bucket/my-job.jar",
+                "main_class": "com.example.MyJob",
+                "app_args": ["--input", "s3://raw/", "--output", "s3://out/"],
+            }
+        }
+        mock_resp = MagicMock()
+        mock_resp.ok = True
+        mock_resp.json.return_value = {"success": True, "submissionId": "driver-jar-003"}
+
+        with patch("requests.post", return_value=mock_resp) as mock_post:
+            executor._submit(workload)
+
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["appArgs"] == ["--input", "s3://raw/", "--output", "s3://out/"]
+
+    def test_jar_submit_applies_spark_properties(self, executor):
+        workload = _make_workload()
+        workload.ti.executor_config = {
+            "spark_jar": {
+                "app_resource": "s3://bucket/my-job.jar",
+                "main_class": "com.example.MyJob",
+                "spark_properties": {"spark.executor.memory": "8g", "spark.executor.cores": "4"},
+            }
+        }
+        mock_resp = MagicMock()
+        mock_resp.ok = True
+        mock_resp.json.return_value = {"success": True, "submissionId": "driver-jar-004"}
+
+        with patch("requests.post", return_value=mock_resp) as mock_post:
+            executor._submit(workload)
+
+        props = mock_post.call_args.kwargs["json"]["sparkProperties"]
+        assert props["spark.executor.memory"] == "8g"
+        assert props["spark.executor.cores"] == "4"
+
+    def test_local_jar_sets_extra_classpath_on_driver_and_executor(self, executor):
+        """file:// JARs must be added to extraClassPath on both sides to fix SerializedLambda deserialization."""
+        workload = _make_workload()
+        workload.ti.executor_config = {
+            "spark_jar": {
+                "app_resource": "file:///opt/spark/examples/jars/my-job.jar",
+                "main_class": "com.example.MyJob",
+            }
+        }
+        mock_resp = MagicMock()
+        mock_resp.ok = True
+        mock_resp.json.return_value = {"success": True, "submissionId": "driver-jar-005"}
+
+        with patch("requests.post", return_value=mock_resp) as mock_post:
+            executor._submit(workload)
+
+        props = mock_post.call_args.kwargs["json"]["sparkProperties"]
+        assert props["spark.driver.extraClassPath"] == "/opt/spark/examples/jars/my-job.jar"
+        assert props["spark.executor.extraClassPath"] == "/opt/spark/examples/jars/my-job.jar"
+        assert "spark.jars" not in props
+
+    def test_remote_jar_uses_spark_jars_not_extra_classpath(self, executor):
+        """Remote URIs (s3://, hdfs://) should use spark.jars for distribution, not extraClassPath."""
+        workload = _make_workload()
+        workload.ti.executor_config = {
+            "spark_jar": {
+                "app_resource": "s3://bucket/my-job.jar",
+                "main_class": "com.example.MyJob",
+            }
+        }
+        mock_resp = MagicMock()
+        mock_resp.ok = True
+        mock_resp.json.return_value = {"success": True, "submissionId": "driver-jar-006"}
+
+        with patch("requests.post", return_value=mock_resp) as mock_post:
+            executor._submit(workload)
+
+        props = mock_post.call_args.kwargs["json"]["sparkProperties"]
+        assert props["spark.jars"] == "s3://bucket/my-job.jar"
+        assert "spark.driver.extraClassPath" not in props
+        assert "spark.executor.extraClassPath" not in props
+
+    def test_spark_properties_override_defaults(self, executor):
+        """User-provided spark_properties must win over executor defaults."""
+        workload = _make_workload()
+        workload.ti.executor_config = {
+            "spark_jar": {
+                "app_resource": "file:///opt/myapp/job.jar",
+                "main_class": "com.example.MyJob",
+                "spark_properties": {
+                    "spark.executor.extraClassPath": "/custom/path.jar",
+                    "spark.driver.memory": "4g",
+                },
+            }
+        }
+        mock_resp = MagicMock()
+        mock_resp.ok = True
+        mock_resp.json.return_value = {"success": True, "submissionId": "driver-jar-007"}
+
+        with patch("requests.post", return_value=mock_resp) as mock_post:
+            executor._submit(workload)
+
+        props = mock_post.call_args.kwargs["json"]["sparkProperties"]
+        assert props["spark.executor.extraClassPath"] == "/custom/path.jar"
+        assert props["spark.driver.memory"] == "4g"
+
+    def test_jar_submit_returns_none_on_failure(self, executor):
+        workload = _make_workload()
+        workload.ti.executor_config = {
+            "spark_jar": {
+                "app_resource": "s3://bucket/my-job.jar",
+                "main_class": "com.example.MyJob",
+            }
+        }
+
+        with patch("requests.post", side_effect=requests.exceptions.ConnectionError("refused")):
+            submission_id = executor._submit(workload)
+
+        assert submission_id is None
+
+    def test_no_spark_jar_key_uses_python_path(self, executor):
+        """executor_config without spark_jar should still go through AirflowDriverLauncher."""
+        workload = _make_workload()
+        workload.ti.executor_config = {"spark_properties": {"spark.driver.memory": "1g"}}
+        mock_resp = MagicMock()
+        mock_resp.ok = True
+        mock_resp.json.return_value = {"success": True, "submissionId": "driver-py-001"}
+
+        with patch("requests.post", return_value=mock_resp) as mock_post:
+            executor._submit(workload)
+
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["mainClass"] == "AirflowDriverLauncher"
+
+
 class TestSparkStandaloneExecutorSync:
     def test_sync_marks_success_on_finished(self, executor):
         key = MagicMock()
@@ -215,3 +390,170 @@ class TestSparkStandaloneExecutorTerminate:
         assert "http://spark-master:6066/v1/submissions/kill/driver-001" in called_urls
         assert "http://spark-master:6066/v1/submissions/kill/driver-002" in called_urls
         assert len(executor._submissions) == 0
+
+
+class TestSparkStandaloneExecutorLogUpload:
+    """Tests for the driver log fetch-and-upload path."""
+
+    def _make_key(self, dag_id="test_dag", task_id="test_task", run_id="run_1", try_number=1):
+        from airflow.models.taskinstancekey import TaskInstanceKey
+
+        key = MagicMock(spec=TaskInstanceKey)
+        key.dag_id = dag_id
+        key.task_id = task_id
+        key.run_id = run_id
+        key.try_number = try_number
+        return key
+
+    def test_upload_skipped_when_remote_logging_not_configured(self, executor):
+        """_upload_driver_logs is a no-op when REMOTE_BASE_LOG_FOLDER is empty."""
+        with (
+            patch.object(executor, "_do_upload_driver_logs") as mock_do,
+            patch.dict("os.environ", {}, clear=False),
+            patch("airflow.configuration.conf.get", return_value=""),
+        ):
+            executor._upload_driver_logs(self._make_key(), "driver-001")
+
+        # _do_upload_driver_logs is called; it exits early internally — verify
+        # by checking no network calls were made
+        mock_do.assert_called_once()
+
+    def test_get_worker_ui_url_matches_worker_host(self, executor):
+        """_get_worker_ui_url finds the right worker via the master JSON API."""
+        executor._master_ui_url = "http://spark-master:8080"
+
+        status_resp = MagicMock()
+        status_resp.json.return_value = {"workerHostPort": "192.168.1.5:36000"}
+
+        master_resp = MagicMock()
+        master_resp.json.return_value = {
+            "workers": [
+                {"host": "192.168.1.4", "webuiaddress": "http://192.168.1.4:8081"},
+                {"host": "192.168.1.5", "webuiaddress": "http://192.168.1.5:8081"},
+            ]
+        }
+
+        with patch("requests.get", side_effect=[status_resp, master_resp]):
+            url = executor._get_worker_ui_url("driver-001")
+
+        assert url == "http://192.168.1.5:8081"
+
+    def test_get_worker_ui_url_returns_none_when_worker_not_found(self, executor):
+        executor._master_ui_url = "http://spark-master:8080"
+
+        status_resp = MagicMock()
+        status_resp.json.return_value = {"workerHostPort": "10.0.0.99:36000"}
+
+        master_resp = MagicMock()
+        master_resp.json.return_value = {
+            "workers": [{"host": "192.168.1.4", "webuiaddress": "http://192.168.1.4:8081"}]
+        }
+
+        with patch("requests.get", side_effect=[status_resp, master_resp]):
+            url = executor._get_worker_ui_url("driver-001")
+
+        assert url is None
+
+    def test_get_worker_ui_url_returns_none_on_connection_error(self, executor):
+        executor._master_ui_url = "http://spark-master:8080"
+
+        with patch("requests.get", side_effect=requests.exceptions.ConnectionError("refused")):
+            url = executor._get_worker_ui_url("driver-001")
+
+        assert url is None
+
+    def test_fetch_driver_log_content_strips_header_and_combines(self, executor):
+        """_fetch_driver_log_content strips the Spark /log/ header line and joins stderr+stdout."""
+        stderr_resp = MagicMock()
+        stderr_resp.ok = True
+        stderr_resp.text = (
+            "==== Bytes 0-20 of 20 of /opt/spark/work/driver-001/stderr ====\nINFO SparkContext: Started\n"
+        )
+
+        stdout_resp = MagicMock()
+        stdout_resp.ok = True
+        stdout_resp.text = (
+            "==== Bytes 0-24 of 24 of /opt/spark/work/driver-001/stdout ====\nPi is roughly 3.14\n"
+        )
+
+        with patch("requests.get", side_effect=[stderr_resp, stdout_resp]):
+            content = executor._fetch_driver_log_content("http://worker:8081", "driver-001")
+
+        assert "INFO SparkContext: Started" in content
+        assert "Pi is roughly 3.14" in content
+        assert "Bytes 0-20" not in content  # header stripped
+        assert "=== Spark driver stderr ===" in content
+        assert "=== Spark driver stdout ===" in content
+
+    def test_fetch_driver_log_content_skips_empty_log(self, executor):
+        """Logs with empty bodies (e.g. 0-byte stdout) are omitted from the combined output."""
+        stderr_resp = MagicMock()
+        stderr_resp.ok = True
+        stderr_resp.text = "==== Bytes 0-10 of 10 of .../stderr ====\nSome error\n"
+
+        stdout_resp = MagicMock()
+        stdout_resp.ok = True
+        stdout_resp.text = "==== Bytes 0-0 of 0 of .../stdout ====\n"
+
+        with patch("requests.get", side_effect=[stderr_resp, stdout_resp]):
+            content = executor._fetch_driver_log_content("http://worker:8081", "driver-001")
+
+        assert "Some error" in content
+        assert "stdout" not in content  # empty stdout section omitted
+
+    def test_write_log_to_remote_uploads_to_s3(self, executor):
+        """_write_log_to_remote calls S3Hook.load_string with the correct bucket and key."""
+        mock_hook = MagicMock()
+
+        with (
+            patch("airflow.providers.amazon.aws.hooks.s3.S3Hook", return_value=mock_hook) as MockHook,
+            patch.dict("os.environ", {"AIRFLOW__LOGGING__REMOTE_LOG_CONN_ID": "minio_logs"}),
+        ):
+            executor._write_log_to_remote(
+                "s3://airflow-logs/",
+                "dag_id=d/run_id=r/task_id=t/attempt=1.log",
+                "log content",
+            )
+
+        MockHook.assert_called_once_with(aws_conn_id="minio_logs")
+        mock_hook.load_string.assert_called_once_with(
+            "log content",
+            key="dag_id=d/run_id=r/task_id=t/attempt=1.log",
+            bucket_name="airflow-logs",
+            replace=True,
+        )
+
+    def test_write_log_to_remote_skips_non_s3_schemes(self, executor):
+        """Non-S3 remote log schemes are silently skipped."""
+        with patch("airflow.providers.amazon.aws.hooks.s3.S3Hook") as MockHook:
+            executor._write_log_to_remote(
+                "gs://my-bucket/",
+                "dag_id=d/run_id=r/task_id=t/attempt=1.log",
+                "log content",
+            )
+
+        MockHook.assert_not_called()
+
+    def test_upload_driver_logs_tolerates_exception(self, executor):
+        """Errors in the log upload path must not propagate — they are logged as warnings."""
+        with patch.object(executor, "_do_upload_driver_logs", side_effect=RuntimeError("boom")):
+            executor._upload_driver_logs(self._make_key(), "driver-001")  # must not raise
+
+    def test_sync_calls_upload_before_state_change_on_success(self, executor):
+        """sync() must upload logs before marking the task successful."""
+        key = MagicMock()
+        executor._submissions[key] = "driver-001"
+        executor.running.add(key)
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"driverState": "FINISHED"}
+
+        call_order = []
+        with (
+            patch("requests.get", return_value=mock_resp),
+            patch.object(executor, "_upload_driver_logs", side_effect=lambda *a: call_order.append("upload")),
+            patch.object(executor, "success", side_effect=lambda *a: call_order.append("success")),
+        ):
+            executor.sync()
+
+        assert call_order == ["upload", "success"]

--- a/providers/apache/spark/tests/unit/apache/spark/executors/test_spark_standalone_executor.py
+++ b/providers/apache/spark/tests/unit/apache/spark/executors/test_spark_standalone_executor.py
@@ -1,0 +1,217 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from airflow.providers.apache.spark.executors.spark_standalone_executor import (
+    _DRIVER_STATE_SUCCESS,
+    _DRIVER_STATE_TERMINAL_FAILURE,
+    SparkStandaloneExecutor,
+)
+from airflow.utils.state import TaskInstanceState
+
+
+def _make_workload(dag_id="test_dag", task_id="test_task", run_id="run_1", try_number=1, map_index=-1):
+    """Build a minimal mock ExecuteTask workload."""
+    ti = MagicMock()
+    ti.dag_id = dag_id
+    ti.task_id = task_id
+    ti.run_id = run_id
+    ti.try_number = try_number
+    ti.map_index = map_index
+    ti.executor_config = None
+    ti.key = MagicMock()
+    ti.key.__hash__ = lambda self: hash((dag_id, task_id, run_id, try_number, map_index))
+    ti.key.__eq__ = lambda self, other: self is other
+
+    workload = MagicMock()
+    workload.ti = ti
+    workload.token = "test-jwt-token"
+    return workload
+
+
+@pytest.fixture
+def executor(monkeypatch):
+    """Return a SparkStandaloneExecutor with config pre-populated (no airflow.cfg needed)."""
+    exc = SparkStandaloneExecutor(parallelism=4)
+    exc._rest_url = "http://spark-master:6066/v1/submissions"
+    exc._master_url = "spark://spark-master:7077"
+    exc._task_runner_script = "file:///opt/airflow/scripts/airflow_task_runner.py"
+    exc._spark_version = "3.5.0"
+    exc._driver_memory = "512m"
+    exc._executor_memory = "1g"
+    exc._executor_cores = "1"
+    exc._submission_timeout = 30
+    return exc
+
+
+class TestSparkStandaloneExecutorSubmit:
+    def test_submit_returns_submission_id_on_success(self, executor):
+        workload = _make_workload()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"success": True, "submissionId": "driver-001"}
+
+        with patch("requests.post", return_value=mock_resp) as mock_post:
+            submission_id = executor._submit(workload)
+
+        assert submission_id == "driver-001"
+        mock_post.assert_called_once()
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["action"] == "CreateSubmissionRequest"
+        assert payload["sparkProperties"]["spark.submit.deployMode"] == "cluster"
+        assert payload["sparkProperties"]["spark.master"] == "spark://spark-master:7077"
+
+    def test_submit_returns_none_when_spark_rejects(self, executor):
+        workload = _make_workload()
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"success": False, "message": "No resources available"}
+
+        with patch("requests.post", return_value=mock_resp):
+            submission_id = executor._submit(workload)
+
+        assert submission_id is None
+
+    def test_submit_returns_none_on_connection_error(self, executor):
+        workload = _make_workload()
+
+        with patch("requests.post", side_effect=requests.exceptions.ConnectionError("refused")):
+            submission_id = executor._submit(workload)
+
+        assert submission_id is None
+
+    def test_submit_includes_env_vars(self, executor):
+        import json
+
+        workload = _make_workload(dag_id="my_dag", task_id="my_task", run_id="run_42")
+        # model_dump_json() must return a real JSON string so the assertion can inspect it
+        workload.model_dump_json.return_value = json.dumps(
+            {"dag_id": "my_dag", "task_id": "my_task", "run_id": "run_42"}
+        )
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"success": True, "submissionId": "driver-002"}
+
+        with patch("requests.post", return_value=mock_resp) as mock_post:
+            with patch("airflow.configuration.conf.get", return_value=""):
+                executor._submit(workload)
+
+        env = mock_post.call_args.kwargs["json"]["environmentVariables"]
+        # Full workload JSON is passed — same mechanism as KubernetesExecutor
+        assert "AIRFLOW_EXECUTE_WORKLOAD" in env
+        workload_json = env["AIRFLOW_EXECUTE_WORKLOAD"]
+        assert "my_dag" in workload_json
+        assert "my_task" in workload_json
+        assert "run_42" in workload_json
+
+    def test_submit_applies_executor_config_spark_properties(self, executor):
+        workload = _make_workload()
+        workload.ti.executor_config = {"spark_properties": {"spark.executor.memory": "4g"}}
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"success": True, "submissionId": "driver-003"}
+
+        with patch("requests.post", return_value=mock_resp) as mock_post:
+            executor._submit(workload)
+
+        props = mock_post.call_args.kwargs["json"]["sparkProperties"]
+        assert props["spark.executor.memory"] == "4g"
+
+
+class TestSparkStandaloneExecutorSync:
+    def test_sync_marks_success_on_finished(self, executor):
+        key = MagicMock()
+        executor._submissions[key] = "driver-001"
+        executor.running.add(key)
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"driverState": _DRIVER_STATE_SUCCESS}
+
+        with patch("requests.get", return_value=mock_resp):
+            executor.sync()
+
+        assert key not in executor._submissions
+        assert (key, TaskInstanceState.SUCCESS) in [(k, v[0]) for k, v in executor.event_buffer.items()]
+
+    @pytest.mark.parametrize("driver_state", list(_DRIVER_STATE_TERMINAL_FAILURE))
+    def test_sync_marks_failed_on_terminal_states(self, executor, driver_state):
+        key = MagicMock()
+        executor._submissions[key] = "driver-002"
+        executor.running.add(key)
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"driverState": driver_state}
+
+        with patch("requests.get", return_value=mock_resp):
+            executor.sync()
+
+        assert key not in executor._submissions
+        assert (key, TaskInstanceState.FAILED) in [(k, v[0]) for k, v in executor.event_buffer.items()]
+
+    def test_sync_leaves_in_progress_tasks_running(self, executor):
+        key = MagicMock()
+        executor._submissions[key] = "driver-003"
+        executor.running.add(key)
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"driverState": "RUNNING"}
+
+        with patch("requests.get", return_value=mock_resp):
+            executor.sync()
+
+        assert key in executor._submissions
+        assert key not in executor.event_buffer
+
+    def test_sync_tolerates_request_error(self, executor):
+        key = MagicMock()
+        executor._submissions[key] = "driver-004"
+        executor.running.add(key)
+
+        with patch("requests.get", side_effect=requests.exceptions.ConnectionError("timeout")):
+            executor.sync()  # must not raise
+
+        # Task should remain in-flight to be retried next sync cycle
+        assert key in executor._submissions
+
+
+class TestSparkStandaloneExecutorConnectivity:
+    def test_validate_connectivity_succeeds_on_any_http_response(self, executor):
+        mock_resp = MagicMock(status_code=404)
+        with patch("requests.get", return_value=mock_resp):
+            executor._validate_connectivity(timeout=5)  # must not raise
+
+    def test_validate_connectivity_raises_on_connection_error(self, executor):
+        with patch("requests.get", side_effect=requests.exceptions.ConnectionError("refused")):
+            with pytest.raises(RuntimeError, match="cannot reach Spark REST API"):
+                executor._validate_connectivity(timeout=5)
+
+
+class TestSparkStandaloneExecutorTerminate:
+    def test_end_kills_all_running_submissions(self, executor):
+        key1, key2 = MagicMock(), MagicMock()
+        executor._submissions[key1] = "driver-001"
+        executor._submissions[key2] = "driver-002"
+
+        with patch("requests.post") as mock_post:
+            executor.end()
+
+        assert mock_post.call_count == 2
+        called_urls = {call.args[0] for call in mock_post.call_args_list}
+        assert "http://spark-master:6066/v1/submissions/kill/driver-001" in called_urls
+        assert "http://spark-master:6066/v1/submissions/kill/driver-002" in called_urls
+        assert len(executor._submissions) == 0

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
@@ -3454,6 +3454,7 @@ dependencies = [
     { name = "apache-airflow-providers-common-compat" },
     { name = "grpcio-status" },
     { name = "pyspark-client" },
+    { name = "requests" },
 ]
 
 [package.optional-dependencies]
@@ -3490,6 +3491,7 @@ requires-dist = [
     { name = "grpcio-status", specifier = ">=1.67.0" },
     { name = "pyspark", marker = "extra == 'pyspark'", specifier = ">=4.0.0" },
     { name = "pyspark-client", specifier = ">=4.0.0" },
+    { name = "requests", specifier = ">=2.27.0" },
 ]
 provides-extras = ["cncf-kubernetes", "openlineage", "pyspark"]
 
@@ -10856,69 +10858,6 @@ wheels = [
 ]
 
 [[package]]
-name = "fastuuid"
-version = "0.14.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/7d/d9daedf0f2ebcacd20d599928f8913e9d2aea1d56d2d355a93bfa2b611d7/fastuuid-0.14.0.tar.gz", hash = "sha256:178947fc2f995b38497a74172adee64fdeb8b7ec18f2a5934d037641ba265d26", size = 18232, upload-time = "2025-10-19T22:19:22.402Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/b2/731a6696e37cd20eed353f69a09f37a984a43c9713764ee3f7ad5f57f7f9/fastuuid-0.14.0-cp310-cp310-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:6e6243d40f6c793c3e2ee14c13769e341b90be5ef0c23c82fa6515a96145181a", size = 516760, upload-time = "2025-10-19T22:25:21.509Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/79/c73c47be2a3b8734d16e628982653517f80bbe0570e27185d91af6096507/fastuuid-0.14.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:13ec4f2c3b04271f62be2e1ce7e95ad2dd1cf97e94503a3760db739afbd48f00", size = 264748, upload-time = "2025-10-19T22:41:52.873Z" },
-    { url = "https://files.pythonhosted.org/packages/24/c5/84c1eea05977c8ba5173555b0133e3558dc628bcf868d6bf1689ff14aedc/fastuuid-0.14.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b2fdd48b5e4236df145a149d7125badb28e0a383372add3fbaac9a6b7a394470", size = 254537, upload-time = "2025-10-19T22:33:55.603Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/23/4e362367b7fa17dbed646922f216b9921efb486e7abe02147e4b917359f8/fastuuid-0.14.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f74631b8322d2780ebcf2d2d75d58045c3e9378625ec51865fe0b5620800c39d", size = 278994, upload-time = "2025-10-19T22:26:17.631Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/72/3985be633b5a428e9eaec4287ed4b873b7c4c53a9639a8b416637223c4cd/fastuuid-0.14.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83cffc144dc93eb604b87b179837f2ce2af44871a7b323f2bfed40e8acb40ba8", size = 280003, upload-time = "2025-10-19T22:23:45.415Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/6d/6ef192a6df34e2266d5c9deb39cd3eea986df650cbcfeaf171aa52a059c3/fastuuid-0.14.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a771f135ab4523eb786e95493803942a5d1fc1610915f131b363f55af53b219", size = 303583, upload-time = "2025-10-19T22:26:00.756Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/11/8a2ea753c68d4fece29d5d7c6f3f903948cc6e82d1823bc9f7f7c0355db3/fastuuid-0.14.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4edc56b877d960b4eda2c4232f953a61490c3134da94f3c28af129fb9c62a4f6", size = 460955, upload-time = "2025-10-19T22:36:25.196Z" },
-    { url = "https://files.pythonhosted.org/packages/23/42/7a32c93b6ce12642d9a152ee4753a078f372c9ebb893bc489d838dd4afd5/fastuuid-0.14.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:bcc96ee819c282e7c09b2eed2b9bd13084e3b749fdb2faf58c318d498df2efbe", size = 480763, upload-time = "2025-10-19T22:24:28.451Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/e9/a5f6f686b46e3ed4ed3b93770111c233baac87dd6586a411b4988018ef1d/fastuuid-0.14.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:7a3c0bca61eacc1843ea97b288d6789fbad7400d16db24e36a66c28c268cfe3d", size = 452613, upload-time = "2025-10-19T22:25:06.827Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/c9/18abc73c9c5b7fc0e476c1733b678783b2e8a35b0be9babd423571d44e98/fastuuid-0.14.0-cp310-cp310-win32.whl", hash = "sha256:7f2f3efade4937fae4e77efae1af571902263de7b78a0aee1a1653795a093b2a", size = 155045, upload-time = "2025-10-19T22:28:32.732Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/8a/d9e33f4eb4d4f6d9f2c5c7d7e96b5cdbb535c93f3b1ad6acce97ee9d4bf8/fastuuid-0.14.0-cp310-cp310-win_amd64.whl", hash = "sha256:ae64ba730d179f439b0736208b4c279b8bc9c089b102aec23f86512ea458c8a4", size = 156122, upload-time = "2025-10-19T22:23:15.59Z" },
-    { url = "https://files.pythonhosted.org/packages/98/f3/12481bda4e5b6d3e698fbf525df4443cc7dce746f246b86b6fcb2fba1844/fastuuid-0.14.0-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:73946cb950c8caf65127d4e9a325e2b6be0442a224fd51ba3b6ac44e1912ce34", size = 516386, upload-time = "2025-10-19T22:42:40.176Z" },
-    { url = "https://files.pythonhosted.org/packages/59/19/2fc58a1446e4d72b655648eb0879b04e88ed6fa70d474efcf550f640f6ec/fastuuid-0.14.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:12ac85024637586a5b69645e7ed986f7535106ed3013640a393a03e461740cb7", size = 264569, upload-time = "2025-10-19T22:25:50.977Z" },
-    { url = "https://files.pythonhosted.org/packages/78/29/3c74756e5b02c40cfcc8b1d8b5bac4edbd532b55917a6bcc9113550e99d1/fastuuid-0.14.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:05a8dde1f395e0c9b4be515b7a521403d1e8349443e7641761af07c7ad1624b1", size = 254366, upload-time = "2025-10-19T22:29:49.166Z" },
-    { url = "https://files.pythonhosted.org/packages/52/96/d761da3fccfa84f0f353ce6e3eb8b7f76b3aa21fd25e1b00a19f9c80a063/fastuuid-0.14.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:09378a05020e3e4883dfdab438926f31fea15fd17604908f3d39cbeb22a0b4dc", size = 278978, upload-time = "2025-10-19T22:35:41.306Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/c2/f84c90167cc7765cb82b3ff7808057608b21c14a38531845d933a4637307/fastuuid-0.14.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bbb0c4b15d66b435d2538f3827f05e44e2baafcc003dd7d8472dc67807ab8fd8", size = 279692, upload-time = "2025-10-19T22:25:36.997Z" },
-    { url = "https://files.pythonhosted.org/packages/af/7b/4bacd03897b88c12348e7bd77943bac32ccf80ff98100598fcff74f75f2e/fastuuid-0.14.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:cd5a7f648d4365b41dbf0e38fe8da4884e57bed4e77c83598e076ac0c93995e7", size = 303384, upload-time = "2025-10-19T22:29:46.578Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/a2/584f2c29641df8bd810d00c1f21d408c12e9ad0c0dafdb8b7b29e5ddf787/fastuuid-0.14.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:c0a94245afae4d7af8c43b3159d5e3934c53f47140be0be624b96acd672ceb73", size = 460921, upload-time = "2025-10-19T22:36:42.006Z" },
-    { url = "https://files.pythonhosted.org/packages/24/68/c6b77443bb7764c760e211002c8638c0c7cce11cb584927e723215ba1398/fastuuid-0.14.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:2b29e23c97e77c3a9514d70ce343571e469098ac7f5a269320a0f0b3e193ab36", size = 480575, upload-time = "2025-10-19T22:28:18.975Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/87/93f553111b33f9bb83145be12868c3c475bf8ea87c107063d01377cc0e8e/fastuuid-0.14.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:1e690d48f923c253f28151b3a6b4e335f2b06bf669c68a02665bc150b7839e94", size = 452317, upload-time = "2025-10-19T22:25:32.75Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/8c/a04d486ca55b5abb7eaa65b39df8d891b7b1635b22db2163734dc273579a/fastuuid-0.14.0-cp311-cp311-win32.whl", hash = "sha256:a6f46790d59ab38c6aa0e35c681c0484b50dc0acf9e2679c005d61e019313c24", size = 154804, upload-time = "2025-10-19T22:24:15.615Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/b2/2d40bf00820de94b9280366a122cbaa60090c8cf59e89ac3938cf5d75895/fastuuid-0.14.0-cp311-cp311-win_amd64.whl", hash = "sha256:e150eab56c95dc9e3fefc234a0eedb342fac433dacc273cd4d150a5b0871e1fa", size = 156099, upload-time = "2025-10-19T22:24:31.646Z" },
-    { url = "https://files.pythonhosted.org/packages/02/a2/e78fcc5df65467f0d207661b7ef86c5b7ac62eea337c0c0fcedbeee6fb13/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77e94728324b63660ebf8adb27055e92d2e4611645bf12ed9d88d30486471d0a", size = 510164, upload-time = "2025-10-19T22:31:45.635Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/b3/c846f933f22f581f558ee63f81f29fa924acd971ce903dab1a9b6701816e/fastuuid-0.14.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:caa1f14d2102cb8d353096bc6ef6c13b2c81f347e6ab9d6fbd48b9dea41c153d", size = 261837, upload-time = "2025-10-19T22:38:38.53Z" },
-    { url = "https://files.pythonhosted.org/packages/54/ea/682551030f8c4fa9a769d9825570ad28c0c71e30cf34020b85c1f7ee7382/fastuuid-0.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d23ef06f9e67163be38cece704170486715b177f6baae338110983f99a72c070", size = 251370, upload-time = "2025-10-19T22:40:26.07Z" },
-    { url = "https://files.pythonhosted.org/packages/14/dd/5927f0a523d8e6a76b70968e6004966ee7df30322f5fc9b6cdfb0276646a/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c9ec605ace243b6dbe3bd27ebdd5d33b00d8d1d3f580b39fdd15cd96fd71796", size = 277766, upload-time = "2025-10-19T22:37:23.779Z" },
-    { url = "https://files.pythonhosted.org/packages/16/6e/c0fb547eef61293153348f12e0f75a06abb322664b34a1573a7760501336/fastuuid-0.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:808527f2407f58a76c916d6aa15d58692a4a019fdf8d4c32ac7ff303b7d7af09", size = 278105, upload-time = "2025-10-19T22:26:56.821Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/b1/b9c75e03b768f61cf2e84ee193dc18601aeaf89a4684b20f2f0e9f52b62c/fastuuid-0.14.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2fb3c0d7fef6674bbeacdd6dbd386924a7b60b26de849266d1ff6602937675c8", size = 301564, upload-time = "2025-10-19T22:30:31.604Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/fa/f7395fdac07c7a54f18f801744573707321ca0cee082e638e36452355a9d/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab3f5d36e4393e628a4df337c2c039069344db5f4b9d2a3c9cea48284f1dd741", size = 459659, upload-time = "2025-10-19T22:31:32.341Z" },
-    { url = "https://files.pythonhosted.org/packages/66/49/c9fd06a4a0b1f0f048aacb6599e7d96e5d6bc6fa680ed0d46bf111929d1b/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:b9a0ca4f03b7e0b01425281ffd44e99d360e15c895f1907ca105854ed85e2057", size = 478430, upload-time = "2025-10-19T22:26:22.962Z" },
-    { url = "https://files.pythonhosted.org/packages/be/9c/909e8c95b494e8e140e8be6165d5fc3f61fdc46198c1554df7b3e1764471/fastuuid-0.14.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:3acdf655684cc09e60fb7e4cf524e8f42ea760031945aa8086c7eae2eeeabeb8", size = 450894, upload-time = "2025-10-19T22:27:01.647Z" },
-    { url = "https://files.pythonhosted.org/packages/90/eb/d29d17521976e673c55ef7f210d4cdd72091a9ec6755d0fd4710d9b3c871/fastuuid-0.14.0-cp312-cp312-win32.whl", hash = "sha256:9579618be6280700ae36ac42c3efd157049fe4dd40ca49b021280481c78c3176", size = 154374, upload-time = "2025-10-19T22:29:19.879Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/fc/f5c799a6ea6d877faec0472d0b27c079b47c86b1cdc577720a5386483b36/fastuuid-0.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:d9e4332dc4ba054434a9594cbfaf7823b57993d7d8e7267831c3e059857cf397", size = 156550, upload-time = "2025-10-19T22:27:49.658Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/83/ae12dd39b9a39b55d7f90abb8971f1a5f3c321fd72d5aa83f90dc67fe9ed/fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:77a09cb7427e7af74c594e409f7731a0cf887221de2f698e1ca0ebf0f3139021", size = 510720, upload-time = "2025-10-19T22:42:34.633Z" },
-    { url = "https://files.pythonhosted.org/packages/53/b0/a4b03ff5d00f563cc7546b933c28cb3f2a07344b2aec5834e874f7d44143/fastuuid-0.14.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:9bd57289daf7b153bfa3e8013446aa144ce5e8c825e9e366d455155ede5ea2dc", size = 262024, upload-time = "2025-10-19T22:30:25.482Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/6d/64aee0a0f6a58eeabadd582e55d0d7d70258ffdd01d093b30c53d668303b/fastuuid-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ac60fc860cdf3c3f327374db87ab8e064c86566ca8c49d2e30df15eda1b0c2d5", size = 251679, upload-time = "2025-10-19T22:36:14.096Z" },
-    { url = "https://files.pythonhosted.org/packages/60/f5/a7e9cda8369e4f7919d36552db9b2ae21db7915083bc6336f1b0082c8b2e/fastuuid-0.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab32f74bd56565b186f036e33129da77db8be09178cd2f5206a5d4035fb2a23f", size = 277862, upload-time = "2025-10-19T22:36:23.302Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/d3/8ce11827c783affffd5bd4d6378b28eb6cc6d2ddf41474006b8d62e7448e/fastuuid-0.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33e678459cf4addaedd9936bbb038e35b3f6b2061330fd8f2f6a1d80414c0f87", size = 278278, upload-time = "2025-10-19T22:29:43.809Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/51/680fb6352d0bbade04036da46264a8001f74b7484e2fd1f4da9e3db1c666/fastuuid-0.14.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1e3cc56742f76cd25ecb98e4b82a25f978ccffba02e4bdce8aba857b6d85d87b", size = 301788, upload-time = "2025-10-19T22:36:06.825Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/7c/2014b5785bd8ebdab04ec857635ebd84d5ee4950186a577db9eff0fb8ff6/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cb9a030f609194b679e1660f7e32733b7a0f332d519c5d5a6a0a580991290022", size = 459819, upload-time = "2025-10-19T22:35:31.623Z" },
-    { url = "https://files.pythonhosted.org/packages/01/d2/524d4ceeba9160e7a9bc2ea3e8f4ccf1ad78f3bde34090ca0c51f09a5e91/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:09098762aad4f8da3a888eb9ae01c84430c907a297b97166b8abc07b640f2995", size = 478546, upload-time = "2025-10-19T22:26:03.023Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/17/354d04951ce114bf4afc78e27a18cfbd6ee319ab1829c2d5fb5e94063ac6/fastuuid-0.14.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:1383fff584fa249b16329a059c68ad45d030d5a4b70fb7c73a08d98fd53bcdab", size = 450921, upload-time = "2025-10-19T22:31:02.151Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/be/d7be8670151d16d88f15bb121c5b66cdb5ea6a0c2a362d0dcf30276ade53/fastuuid-0.14.0-cp313-cp313-win32.whl", hash = "sha256:a0809f8cc5731c066c909047f9a314d5f536c871a7a22e815cc4967c110ac9ad", size = 154559, upload-time = "2025-10-19T22:36:36.011Z" },
-    { url = "https://files.pythonhosted.org/packages/22/1d/5573ef3624ceb7abf4a46073d3554e37191c868abc3aecd5289a72f9810a/fastuuid-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:0df14e92e7ad3276327631c9e7cec09e32572ce82089c55cb1bb8df71cf394ed", size = 156539, upload-time = "2025-10-19T22:33:35.898Z" },
-    { url = "https://files.pythonhosted.org/packages/16/c9/8c7660d1fe3862e3f8acabd9be7fc9ad71eb270f1c65cce9a2b7a31329ab/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:b852a870a61cfc26c884af205d502881a2e59cc07076b60ab4a951cc0c94d1ad", size = 510600, upload-time = "2025-10-19T22:43:44.17Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/f4/a989c82f9a90d0ad995aa957b3e572ebef163c5299823b4027986f133dfb/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c7502d6f54cd08024c3ea9b3514e2d6f190feb2f46e6dbcd3747882264bb5f7b", size = 262069, upload-time = "2025-10-19T22:43:38.38Z" },
-    { url = "https://files.pythonhosted.org/packages/da/6c/a1a24f73574ac995482b1326cf7ab41301af0fabaa3e37eeb6b3df00e6e2/fastuuid-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1ca61b592120cf314cfd66e662a5b54a578c5a15b26305e1b8b618a6f22df714", size = 251543, upload-time = "2025-10-19T22:32:22.537Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/20/2a9b59185ba7a6c7b37808431477c2d739fcbdabbf63e00243e37bd6bf49/fastuuid-0.14.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:aa75b6657ec129d0abded3bec745e6f7ab642e6dba3a5272a68247e85f5f316f", size = 277798, upload-time = "2025-10-19T22:33:53.821Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/33/4105ca574f6ded0af6a797d39add041bcfb468a1255fbbe82fcb6f592da2/fastuuid-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a8a0dfea3972200f72d4c7df02c8ac70bad1bb4c58d7e0ec1e6f341679073a7f", size = 278283, upload-time = "2025-10-19T22:29:02.812Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/8c/fca59f8e21c4deb013f574eae05723737ddb1d2937ce87cb2a5d20992dc3/fastuuid-0.14.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1bf539a7a95f35b419f9ad105d5a8a35036df35fdafae48fb2fd2e5f318f0d75", size = 301627, upload-time = "2025-10-19T22:35:54.985Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/e2/f78c271b909c034d429218f2798ca4e89eeda7983f4257d7865976ddbb6c/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:9a133bf9cc78fdbd1179cb58a59ad0100aa32d8675508150f3658814aeefeaa4", size = 459778, upload-time = "2025-10-19T22:28:00.999Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/f0/5ff209d865897667a2ff3e7a572267a9ced8f7313919f6d6043aed8b1caa/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_i686.whl", hash = "sha256:f54d5b36c56a2d5e1a31e73b950b28a0d83eb0c37b91d10408875a5a29494bad", size = 478605, upload-time = "2025-10-19T22:36:21.764Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/c8/2ce1c78f983a2c4987ea865d9516dbdfb141a120fd3abb977ae6f02ba7ca/fastuuid-0.14.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:ec27778c6ca3393ef662e2762dba8af13f4ec1aaa32d08d77f71f2a70ae9feb8", size = 450837, upload-time = "2025-10-19T22:34:37.178Z" },
-    { url = "https://files.pythonhosted.org/packages/df/60/dad662ec9a33b4a5fe44f60699258da64172c39bd041da2994422cdc40fe/fastuuid-0.14.0-cp314-cp314-win32.whl", hash = "sha256:e23fc6a83f112de4be0cc1990e5b127c27663ae43f866353166f87df58e73d06", size = 154532, upload-time = "2025-10-19T22:35:18.217Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/f6/da4db31001e854025ffd26bc9ba0740a9cbba2c3259695f7c5834908b336/fastuuid-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:df61342889d0f5e7a32f7284e55ef95103f2110fee433c2ae7c2c0956d76ac8a", size = 156457, upload-time = "2025-10-19T22:33:44.579Z" },
-]
-
-[[package]]
 name = "filelock"
 version = "3.25.2"
 source = { registry = "https://pypi.org/simple" }
@@ -11548,7 +11487,7 @@ wheels = [
 
 [[package]]
 name = "google-cloud-aiplatform"
-version = "1.141.0"
+version = "1.99.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docstring-parser" },
@@ -11562,17 +11501,17 @@ dependencies = [
     { name = "proto-plus" },
     { name = "protobuf" },
     { name = "pydantic" },
+    { name = "shapely" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ac/dc/1209c7aab43bd7233cf631165a3b1b4284d22fc7fe7387c66228d07868ab/google_cloud_aiplatform-1.141.0.tar.gz", hash = "sha256:e3b1cdb28865dd862aac9c685dfc5ac076488705aba0a5354016efadcddd59c6", size = 10152688, upload-time = "2026-03-10T22:20:08.692Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/e5/fa4cc399206c0bda9544903bb6c373262cea688383276df5775cac7c9c6e/google_cloud_aiplatform-1.99.0.tar.gz", hash = "sha256:ea509e0d58e456a4c3d9bd007a8c273cbd0ae7e8542258869a418a1a4e68ec3b", size = 9286233, upload-time = "2025-06-24T19:45:17.181Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/fc/428af69a69ff2e477e7f5e12d227b31fe5790f1a8234aacd54297f49c836/google_cloud_aiplatform-1.141.0-py2.py3-none-any.whl", hash = "sha256:6bd25b4d514c40b8181ca703e1b313ad6d0454ab8006fc9907fb3e9f672f31d1", size = 8358409, upload-time = "2026-03-10T22:20:04.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/27/a16b8d8d2a9ae643c34af6c381a918964bd4ae204a3458210a7c97f7f985/google_cloud_aiplatform-1.99.0-py2.py3-none-any.whl", hash = "sha256:3026fadb11900f3d1bb95cb75dedd15e04de8521ab64815dae292b52ccf84917", size = 7721474, upload-time = "2025-06-24T19:45:14.478Z" },
 ]
 
 [package.optional-dependencies]
 evaluation = [
     { name = "jsonschema" },
-    { name = "litellm" },
     { name = "pandas" },
     { name = "pyyaml" },
     { name = "ruamel-yaml" },
@@ -12169,7 +12108,7 @@ wheels = [
 
 [[package]]
 name = "google-cloud-storage"
-version = "3.4.1"
+version = "2.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core" },
@@ -12179,9 +12118,9 @@ dependencies = [
     { name = "google-resumable-media" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/ef/7cefdca67a6c8b3af0ec38612f9e78e5a9f6179dd91352772ae1a9849246/google_cloud_storage-3.4.1.tar.gz", hash = "sha256:6f041a297e23a4b485fad8c305a7a6e6831855c208bcbe74d00332a909f82268", size = 17238203, upload-time = "2025-10-08T18:43:39.665Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/76/4d965702e96bb67976e755bed9828fa50306dca003dbee08b67f41dd265e/google_cloud_storage-2.19.0.tar.gz", hash = "sha256:cd05e9e7191ba6cb68934d8eb76054d9be4562aa89dbc4236feee4d7d51342b2", size = 5535488, upload-time = "2024-12-05T01:35:06.49Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/6e/b47d83d3a35231c6232566341b0355cce78fd4e6988a7343725408547b2c/google_cloud_storage-3.4.1-py3-none-any.whl", hash = "sha256:972764cc0392aa097be8f49a5354e22eb47c3f62370067fb1571ffff4a1c1189", size = 290142, upload-time = "2025-10-08T18:43:37.524Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/94/6db383d8ee1adf45dc6c73477152b82731fa4c4a46d9c1932cc8757e0fd4/google_cloud_storage-2.19.0-py2.py3-none-any.whl", hash = "sha256:aeb971b5c29cf8ab98445082cbfe7b161a1f48ed275822f59ed3f1524ea54fba", size = 131787, upload-time = "2024-12-05T01:35:04.736Z" },
 ]
 
 [[package]]
@@ -12517,6 +12456,7 @@ dependencies = [
     { name = "griffecli" },
     { name = "griffelib" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/04/56/28a0accac339c164b52a92c6cfc45a903acc0c174caa5c1713803467b533/griffe-2.0.0.tar.gz", hash = "sha256:c68979cd8395422083a51ea7cf02f9c119d889646d99b7b656ee43725de1b80f", size = 293906, upload-time = "2026-03-23T21:06:53.402Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/94/ee21d41e7eb4f823b94603b9d40f86d3c7fde80eacc2c3c71845476dddaa/griffe-2.0.0-py3-none-any.whl", hash = "sha256:5418081135a391c3e6e757a7f3f156f1a1a746cc7b4023868ff7d5e2f9a980aa", size = 5214, upload-time = "2026-02-09T19:09:44.105Z" },
 ]
@@ -12529,6 +12469,7 @@ dependencies = [
     { name = "colorama" },
     { name = "griffelib" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/f8/2e129fd4a86e52e58eefe664de05e7d502decf766e7316cc9e70fdec3e18/griffecli-2.0.0.tar.gz", hash = "sha256:312fa5ebb4ce6afc786356e2d0ce85b06c1c20d45abc42d74f0cda65e159f6ef", size = 56213, upload-time = "2026-03-23T21:06:54.8Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/ed/d93f7a447bbf7a935d8868e9617cbe1cadf9ee9ee6bd275d3040fbf93d60/griffecli-2.0.0-py3-none-any.whl", hash = "sha256:9f7cd9ee9b21d55e91689358978d2385ae65c22f307a63fb3269acf3f21e643d", size = 9345, upload-time = "2026-02-09T19:09:42.554Z" },
 ]
@@ -12537,6 +12478,7 @@ wheels = [
 name = "griffelib"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/06/eccbd311c9e2b3ca45dbc063b93134c57a1ccc7607c5e545264ad092c4a9/griffelib-2.0.0.tar.gz", hash = "sha256:e504d637a089f5cab9b5daf18f7645970509bf4f53eda8d79ed71cce8bd97934", size = 166312, upload-time = "2026-03-23T21:06:55.954Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
 ]
@@ -14215,29 +14157,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878, upload-time = "2026-03-01T07:48:46.098Z" },
-]
-
-[[package]]
-name = "litellm"
-version = "1.82.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiohttp" },
-    { name = "click" },
-    { name = "fastuuid" },
-    { name = "httpx" },
-    { name = "importlib-metadata" },
-    { name = "jinja2" },
-    { name = "jsonschema" },
-    { name = "openai" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "tiktoken" },
-    { name = "tokenizers" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e6/79/b492be13542aebd62aafc0490e4d5d6e8e00ce54240bcabf5c3e46b1a49b/litellm-1.82.4.tar.gz", hash = "sha256:9c52b1c0762cb0593cdc97b26a8e05004e19b03f394ccd0f42fac82eff0d4980", size = 17378196, upload-time = "2026-03-18T01:18:05.378Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/ad/7eaa1121c6b191f2f5f2e8c7379823ece6ec83741a4b3c81b82fe2832401/litellm-1.82.4-py3-none-any.whl", hash = "sha256:d37c34a847e7952a146ed0e2888a24d3edec7787955c6826337395e755ad5c4b", size = 15559801, upload-time = "2026-03-18T01:18:02.026Z" },
 ]
 
 [[package]]
@@ -19979,6 +19898,74 @@ wheels = [
 ]
 
 [[package]]
+name = "shapely"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/bc/0989043118a27cccb4e906a46b7565ce36ca7b57f5a18b78f4f1b0f72d9d/shapely-2.1.2.tar.gz", hash = "sha256:2ed4ecb28320a433db18a5bf029986aa8afcfd740745e78847e330d5d94922a9", size = 315489, upload-time = "2025-09-24T13:51:41.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/89/c3548aa9b9812a5d143986764dededfa48d817714e947398bdda87c77a72/shapely-2.1.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7ae48c236c0324b4e139bea88a306a04ca630f49be66741b340729d380d8f52f", size = 1825959, upload-time = "2025-09-24T13:50:00.682Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8a/7ebc947080442edd614ceebe0ce2cdbd00c25e832c240e1d1de61d0e6b38/shapely-2.1.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:eba6710407f1daa8e7602c347dfc94adc02205ec27ed956346190d66579eb9ea", size = 1629196, upload-time = "2025-09-24T13:50:03.447Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/86/c9c27881c20d00fc409e7e059de569d5ed0abfcec9c49548b124ebddea51/shapely-2.1.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef4a456cc8b7b3d50ccec29642aa4aeda959e9da2fe9540a92754770d5f0cf1f", size = 2951065, upload-time = "2025-09-24T13:50:05.266Z" },
+    { url = "https://files.pythonhosted.org/packages/50/8a/0ab1f7433a2a85d9e9aea5b1fbb333f3b09b309e7817309250b4b7b2cc7a/shapely-2.1.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e38a190442aacc67ff9f75ce60aec04893041f16f97d242209106d502486a142", size = 3058666, upload-time = "2025-09-24T13:50:06.872Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c6/5a30ffac9c4f3ffd5b7113a7f5299ccec4713acd5ee44039778a7698224e/shapely-2.1.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:40d784101f5d06a1fd30b55fc11ea58a61be23f930d934d86f19a180909908a4", size = 3966905, upload-time = "2025-09-24T13:50:09.417Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/72/e92f3035ba43e53959007f928315a68fbcf2eeb4e5ededb6f0dc7ff1ecc3/shapely-2.1.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f6f6cd5819c50d9bcf921882784586aab34a4bd53e7553e175dece6db513a6f0", size = 4129260, upload-time = "2025-09-24T13:50:11.183Z" },
+    { url = "https://files.pythonhosted.org/packages/42/24/605901b73a3d9f65fa958e63c9211f4be23d584da8a1a7487382fac7fdc5/shapely-2.1.2-cp310-cp310-win32.whl", hash = "sha256:fe9627c39c59e553c90f5bc3128252cb85dc3b3be8189710666d2f8bc3a5503e", size = 1544301, upload-time = "2025-09-24T13:50:12.521Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/89/6db795b8dd3919851856bd2ddd13ce434a748072f6fdee42ff30cbd3afa3/shapely-2.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:1d0bfb4b8f661b3b4ec3565fa36c340bfb1cda82087199711f86a88647d26b2f", size = 1722074, upload-time = "2025-09-24T13:50:13.909Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/8d/1ff672dea9ec6a7b5d422eb6d095ed886e2e523733329f75fdcb14ee1149/shapely-2.1.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:91121757b0a36c9aac3427a651a7e6567110a4a67c97edf04f8d55d4765f6618", size = 1820038, upload-time = "2025-09-24T13:50:15.628Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ce/28fab8c772ce5db23a0d86bf0adaee0c4c79d5ad1db766055fa3dab442e2/shapely-2.1.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:16a9c722ba774cf50b5d4541242b4cce05aafd44a015290c82ba8a16931ff63d", size = 1626039, upload-time = "2025-09-24T13:50:16.881Z" },
+    { url = "https://files.pythonhosted.org/packages/70/8b/868b7e3f4982f5006e9395c1e12343c66a8155c0374fdc07c0e6a1ab547d/shapely-2.1.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cc4f7397459b12c0b196c9efe1f9d7e92463cbba142632b4cc6d8bbbbd3e2b09", size = 3001519, upload-time = "2025-09-24T13:50:18.606Z" },
+    { url = "https://files.pythonhosted.org/packages/13/02/58b0b8d9c17c93ab6340edd8b7308c0c5a5b81f94ce65705819b7416dba5/shapely-2.1.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:136ab87b17e733e22f0961504d05e77e7be8c9b5a8184f685b4a91a84efe3c26", size = 3110842, upload-time = "2025-09-24T13:50:21.77Z" },
+    { url = "https://files.pythonhosted.org/packages/af/61/8e389c97994d5f331dcffb25e2fa761aeedfb52b3ad9bcdd7b8671f4810a/shapely-2.1.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:16c5d0fc45d3aa0a69074979f4f1928ca2734fb2e0dde8af9611e134e46774e7", size = 4021316, upload-time = "2025-09-24T13:50:23.626Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/d4/9b2a9fe6039f9e42ccf2cb3e84f219fd8364b0c3b8e7bbc857b5fbe9c14c/shapely-2.1.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6ddc759f72b5b2b0f54a7e7cde44acef680a55019eb52ac63a7af2cf17cb9cd2", size = 4178586, upload-time = "2025-09-24T13:50:25.443Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f6/9840f6963ed4decf76b08fd6d7fed14f8779fb7a62cb45c5617fa8ac6eab/shapely-2.1.2-cp311-cp311-win32.whl", hash = "sha256:2fa78b49485391224755a856ed3b3bd91c8455f6121fee0db0e71cefb07d0ef6", size = 1543961, upload-time = "2025-09-24T13:50:26.968Z" },
+    { url = "https://files.pythonhosted.org/packages/38/1e/3f8ea46353c2a33c1669eb7327f9665103aa3a8dfe7f2e4ef714c210b2c2/shapely-2.1.2-cp311-cp311-win_amd64.whl", hash = "sha256:c64d5c97b2f47e3cd9b712eaced3b061f2b71234b3fc263e0fcf7d889c6559dc", size = 1722856, upload-time = "2025-09-24T13:50:28.497Z" },
+    { url = "https://files.pythonhosted.org/packages/24/c0/f3b6453cf2dfa99adc0ba6675f9aaff9e526d2224cbd7ff9c1a879238693/shapely-2.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fe2533caae6a91a543dec62e8360fe86ffcdc42a7c55f9dfd0128a977a896b94", size = 1833550, upload-time = "2025-09-24T13:50:30.019Z" },
+    { url = "https://files.pythonhosted.org/packages/86/07/59dee0bc4b913b7ab59ab1086225baca5b8f19865e6101db9ebb7243e132/shapely-2.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ba4d1333cc0bc94381d6d4308d2e4e008e0bd128bdcff5573199742ee3634359", size = 1643556, upload-time = "2025-09-24T13:50:32.291Z" },
+    { url = "https://files.pythonhosted.org/packages/26/29/a5397e75b435b9895cd53e165083faed5d12fd9626eadec15a83a2411f0f/shapely-2.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0bd308103340030feef6c111d3eb98d50dc13feea33affc8a6f9fa549e9458a3", size = 2988308, upload-time = "2025-09-24T13:50:33.862Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/37/e781683abac55dde9771e086b790e554811a71ed0b2b8a1e789b7430dd44/shapely-2.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1e7d4d7ad262a48bb44277ca12c7c78cb1b0f56b32c10734ec9a1d30c0b0c54b", size = 3099844, upload-time = "2025-09-24T13:50:35.459Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f3/9876b64d4a5a321b9dc482c92bb6f061f2fa42131cba643c699f39317cb9/shapely-2.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e9eddfe513096a71896441a7c37db72da0687b34752c4e193577a145c71736fc", size = 3988842, upload-time = "2025-09-24T13:50:37.478Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a0/704c7292f7014c7e74ec84eddb7b109e1fbae74a16deae9c1504b1d15565/shapely-2.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:980c777c612514c0cf99bc8a9de6d286f5e186dcaf9091252fcd444e5638193d", size = 4152714, upload-time = "2025-09-24T13:50:39.9Z" },
+    { url = "https://files.pythonhosted.org/packages/53/46/319c9dc788884ad0785242543cdffac0e6530e4d0deb6c4862bc4143dcf3/shapely-2.1.2-cp312-cp312-win32.whl", hash = "sha256:9111274b88e4d7b54a95218e243282709b330ef52b7b86bc6aaf4f805306f454", size = 1542745, upload-time = "2025-09-24T13:50:41.414Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bf/cb6c1c505cb31e818e900b9312d514f381fbfa5c4363edfce0fcc4f8c1a4/shapely-2.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:743044b4cfb34f9a67205cee9279feaf60ba7d02e69febc2afc609047cb49179", size = 1722861, upload-time = "2025-09-24T13:50:43.35Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/90/98ef257c23c46425dc4d1d31005ad7c8d649fe423a38b917db02c30f1f5a/shapely-2.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b510dda1a3672d6879beb319bc7c5fd302c6c354584690973c838f46ec3e0fa8", size = 1832644, upload-time = "2025-09-24T13:50:44.886Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ab/0bee5a830d209adcd3a01f2d4b70e587cdd9fd7380d5198c064091005af8/shapely-2.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8cff473e81017594d20ec55d86b54bc635544897e13a7cfc12e36909c5309a2a", size = 1642887, upload-time = "2025-09-24T13:50:46.735Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5e/7d7f54ba960c13302584c73704d8c4d15404a51024631adb60b126a4ae88/shapely-2.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fe7b77dc63d707c09726b7908f575fc04ff1d1ad0f3fb92aec212396bc6cfe5e", size = 2970931, upload-time = "2025-09-24T13:50:48.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/a2/83fc37e2a58090e3d2ff79175a95493c664bcd0b653dd75cb9134645a4e5/shapely-2.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ed1a5bbfb386ee8332713bf7508bc24e32d24b74fc9a7b9f8529a55db9f4ee6", size = 3082855, upload-time = "2025-09-24T13:50:50.037Z" },
+    { url = "https://files.pythonhosted.org/packages/44/2b/578faf235a5b09f16b5f02833c53822294d7f21b242f8e2d0cf03fb64321/shapely-2.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a84e0582858d841d54355246ddfcbd1fce3179f185da7470f41ce39d001ee1af", size = 3979960, upload-time = "2025-09-24T13:50:51.74Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/04/167f096386120f692cc4ca02f75a17b961858997a95e67a3cb6a7bbd6b53/shapely-2.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dc3487447a43d42adcdf52d7ac73804f2312cbfa5d433a7d2c506dcab0033dfd", size = 4142851, upload-time = "2025-09-24T13:50:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/48/74/fb402c5a6235d1c65a97348b48cdedb75fb19eca2b1d66d04969fc1c6091/shapely-2.1.2-cp313-cp313-win32.whl", hash = "sha256:9c3a3c648aedc9f99c09263b39f2d8252f199cb3ac154fadc173283d7d111350", size = 1541890, upload-time = "2025-09-24T13:50:55.337Z" },
+    { url = "https://files.pythonhosted.org/packages/41/47/3647fe7ad990af60ad98b889657a976042c9988c2807cf322a9d6685f462/shapely-2.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:ca2591bff6645c216695bdf1614fca9c82ea1144d4a7591a466fef64f28f0715", size = 1722151, upload-time = "2025-09-24T13:50:57.153Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/49/63953754faa51ffe7d8189bfbe9ca34def29f8c0e34c67cbe2a2795f269d/shapely-2.1.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2d93d23bdd2ed9dc157b46bc2f19b7da143ca8714464249bef6771c679d5ff40", size = 1834130, upload-time = "2025-09-24T13:50:58.49Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ee/dce001c1984052970ff60eb4727164892fb2d08052c575042a47f5a9e88f/shapely-2.1.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:01d0d304b25634d60bd7cf291828119ab55a3bab87dc4af1e44b07fb225f188b", size = 1642802, upload-time = "2025-09-24T13:50:59.871Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e7/fc4e9a19929522877fa602f705706b96e78376afb7fad09cad5b9af1553c/shapely-2.1.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8d8382dd120d64b03698b7298b89611a6ea6f55ada9d39942838b79c9bc89801", size = 3018460, upload-time = "2025-09-24T13:51:02.08Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/18/7519a25db21847b525696883ddc8e6a0ecaa36159ea88e0fef11466384d0/shapely-2.1.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:19efa3611eef966e776183e338b2d7ea43569ae99ab34f8d17c2c054d3205cc0", size = 3095223, upload-time = "2025-09-24T13:51:04.472Z" },
+    { url = "https://files.pythonhosted.org/packages/48/de/b59a620b1f3a129c3fecc2737104a0a7e04e79335bd3b0a1f1609744cf17/shapely-2.1.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:346ec0c1a0fcd32f57f00e4134d1200e14bf3f5ae12af87ba83ca275c502498c", size = 4030760, upload-time = "2025-09-24T13:51:06.455Z" },
+    { url = "https://files.pythonhosted.org/packages/96/b3/c6655ee7232b417562bae192ae0d3ceaadb1cc0ffc2088a2ddf415456cc2/shapely-2.1.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6305993a35989391bd3476ee538a5c9a845861462327efe00dd11a5c8c709a99", size = 4170078, upload-time = "2025-09-24T13:51:08.584Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/8e/605c76808d73503c9333af8f6cbe7e1354d2d238bda5f88eea36bfe0f42a/shapely-2.1.2-cp313-cp313t-win32.whl", hash = "sha256:c8876673449f3401f278c86eb33224c5764582f72b653a415d0e6672fde887bf", size = 1559178, upload-time = "2025-09-24T13:51:10.73Z" },
+    { url = "https://files.pythonhosted.org/packages/36/f7/d317eb232352a1f1444d11002d477e54514a4a6045536d49d0c59783c0da/shapely-2.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:4a44bc62a10d84c11a7a3d7c1c4fe857f7477c3506e24c9062da0db0ae0c449c", size = 1739756, upload-time = "2025-09-24T13:51:12.105Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/c4/3ce4c2d9b6aabd27d26ec988f08cb877ba9e6e96086eff81bfea93e688c7/shapely-2.1.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:9a522f460d28e2bf4e12396240a5fc1518788b2fcd73535166d748399ef0c223", size = 1831290, upload-time = "2025-09-24T13:51:13.56Z" },
+    { url = "https://files.pythonhosted.org/packages/17/b9/f6ab8918fc15429f79cb04afa9f9913546212d7fb5e5196132a2af46676b/shapely-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1ff629e00818033b8d71139565527ced7d776c269a49bd78c9df84e8f852190c", size = 1641463, upload-time = "2025-09-24T13:51:14.972Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/57/91d59ae525ca641e7ac5551c04c9503aee6f29b92b392f31790fcb1a4358/shapely-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f67b34271dedc3c653eba4e3d7111aa421d5be9b4c4c7d38d30907f796cb30df", size = 2970145, upload-time = "2025-09-24T13:51:16.961Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cb/4948be52ee1da6927831ab59e10d4c29baa2a714f599f1f0d1bc747f5777/shapely-2.1.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:21952dc00df38a2c28375659b07a3979d22641aeb104751e769c3ee825aadecf", size = 3073806, upload-time = "2025-09-24T13:51:18.712Z" },
+    { url = "https://files.pythonhosted.org/packages/03/83/f768a54af775eb41ef2e7bec8a0a0dbe7d2431c3e78c0a8bdba7ab17e446/shapely-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1f2f33f486777456586948e333a56ae21f35ae273be99255a191f5c1fa302eb4", size = 3980803, upload-time = "2025-09-24T13:51:20.37Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/559c7c195807c91c79d38a1f6901384a2878a76fbdf3f1048893a9b7534d/shapely-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cf831a13e0d5a7eb519e96f58ec26e049b1fad411fc6fc23b162a7ce04d9cffc", size = 4133301, upload-time = "2025-09-24T13:51:21.887Z" },
+    { url = "https://files.pythonhosted.org/packages/80/cd/60d5ae203241c53ef3abd2ef27c6800e21afd6c94e39db5315ea0cbafb4a/shapely-2.1.2-cp314-cp314-win32.whl", hash = "sha256:61edcd8d0d17dd99075d320a1dd39c0cb9616f7572f10ef91b4b5b00c4aeb566", size = 1583247, upload-time = "2025-09-24T13:51:23.401Z" },
+    { url = "https://files.pythonhosted.org/packages/74/d4/135684f342e909330e50d31d441ace06bf83c7dc0777e11043f99167b123/shapely-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:a444e7afccdb0999e203b976adb37ea633725333e5b119ad40b1ca291ecf311c", size = 1773019, upload-time = "2025-09-24T13:51:24.873Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/05/a44f3f9f695fa3ada22786dc9da33c933da1cbc4bfe876fe3a100bafe263/shapely-2.1.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:5ebe3f84c6112ad3d4632b1fd2290665aa75d4cef5f6c5d77c4c95b324527c6a", size = 1834137, upload-time = "2025-09-24T13:51:26.665Z" },
+    { url = "https://files.pythonhosted.org/packages/52/7e/4d57db45bf314573427b0a70dfca15d912d108e6023f623947fa69f39b72/shapely-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5860eb9f00a1d49ebb14e881f5caf6c2cf472c7fd38bd7f253bbd34f934eb076", size = 1642884, upload-time = "2025-09-24T13:51:28.029Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/27/4e29c0a55d6d14ad7422bf86995d7ff3f54af0eba59617eb95caf84b9680/shapely-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b705c99c76695702656327b819c9660768ec33f5ce01fa32b2af62b56ba400a1", size = 3018320, upload-time = "2025-09-24T13:51:29.903Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/bb/992e6a3c463f4d29d4cd6ab8963b75b1b1040199edbd72beada4af46bde5/shapely-2.1.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a1fd0ea855b2cf7c9cddaf25543e914dd75af9de08785f20ca3085f2c9ca60b0", size = 3094931, upload-time = "2025-09-24T13:51:32.699Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/16/82e65e21070e473f0ed6451224ed9fa0be85033d17e0c6e7213a12f59d12/shapely-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:df90e2db118c3671a0754f38e36802db75fe0920d211a27481daf50a711fdf26", size = 4030406, upload-time = "2025-09-24T13:51:34.189Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/75/c24ed871c576d7e2b64b04b1fe3d075157f6eb54e59670d3f5ffb36e25c7/shapely-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:361b6d45030b4ac64ddd0a26046906c8202eb60d0f9f53085f5179f1d23021a0", size = 4169511, upload-time = "2025-09-24T13:51:36.297Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f7/b3d1d6d18ebf55236eec1c681ce5e665742aab3c0b7b232720a7d43df7b6/shapely-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:b54df60f1fbdecc8ebc2c5b11870461a6417b3d617f555e5033f1505d36e5735", size = 1602607, upload-time = "2025-09-24T13:51:37.757Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/f6/f09272a71976dfc138129b8faf435d064a811ae2f708cb147dccdf7aacdb/shapely-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:0036ac886e0923417932c2e6369b6c52e38e0ff5d9120b90eef5cd9a5fc5cae9", size = 1796682, upload-time = "2025-09-24T13:51:39.233Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -21003,67 +20990,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fa/fb/5d9ba73be60b32f6fda080a5556cff25e15daf33bafe043c226404b39b25/thrift_sasl-0.4.3.tar.gz", hash = "sha256:5bdd5b760d90a13d9b3abfce873db0425861aa8d6bf25912d3cc0467a4f773da", size = 3962, upload-time = "2021-05-26T12:40:20.875Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/9e/636c24ce1c0d46ce3020c5836c5a375d8e862fa81a240e0e352cc991dcf8/thrift_sasl-0.4.3-py2.py3-none-any.whl", hash = "sha256:d24b49140115e6e2a96d08335cff225a27a28ea71866fb1b2bdb30ca5afca64e", size = 8304, upload-time = "2021-05-26T12:40:19.425Z" },
-]
-
-[[package]]
-name = "tiktoken"
-version = "0.12.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "regex" },
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/ab/4d017d0f76ec3171d469d80fc03dfbb4e48a4bcaddaa831b31d526f05edc/tiktoken-0.12.0.tar.gz", hash = "sha256:b18ba7ee2b093863978fcb14f74b3707cdc8d4d4d3836853ce7ec60772139931", size = 37806, upload-time = "2025-10-06T20:22:45.419Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/89/b3/2cb7c17b6c4cf8ca983204255d3f1d95eda7213e247e6947a0ee2c747a2c/tiktoken-0.12.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:3de02f5a491cfd179aec916eddb70331814bd6bf764075d39e21d5862e533970", size = 1051991, upload-time = "2025-10-06T20:21:34.098Z" },
-    { url = "https://files.pythonhosted.org/packages/27/0f/df139f1df5f6167194ee5ab24634582ba9a1b62c6b996472b0277ec80f66/tiktoken-0.12.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b6cfb6d9b7b54d20af21a912bfe63a2727d9cfa8fbda642fd8322c70340aad16", size = 995798, upload-time = "2025-10-06T20:21:35.579Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/5d/26a691f28ab220d5edc09b9b787399b130f24327ef824de15e5d85ef21aa/tiktoken-0.12.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:cde24cdb1b8a08368f709124f15b36ab5524aac5fa830cc3fdce9c03d4fb8030", size = 1129865, upload-time = "2025-10-06T20:21:36.675Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/94/443fab3d4e5ebecac895712abd3849b8da93b7b7dec61c7db5c9c7ebe40c/tiktoken-0.12.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:6de0da39f605992649b9cfa6f84071e3f9ef2cec458d08c5feb1b6f0ff62e134", size = 1152856, upload-time = "2025-10-06T20:21:37.873Z" },
-    { url = "https://files.pythonhosted.org/packages/54/35/388f941251b2521c70dd4c5958e598ea6d2c88e28445d2fb8189eecc1dfc/tiktoken-0.12.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:6faa0534e0eefbcafaccb75927a4a380463a2eaa7e26000f0173b920e98b720a", size = 1195308, upload-time = "2025-10-06T20:21:39.577Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/00/c6681c7f833dd410576183715a530437a9873fa910265817081f65f9105f/tiktoken-0.12.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:82991e04fc860afb933efb63957affc7ad54f83e2216fe7d319007dab1ba5892", size = 1255697, upload-time = "2025-10-06T20:21:41.154Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/d2/82e795a6a9bafa034bf26a58e68fe9a89eeaaa610d51dbeb22106ba04f0a/tiktoken-0.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:6fb2995b487c2e31acf0a9e17647e3b242235a20832642bb7a9d1a181c0c1bb1", size = 879375, upload-time = "2025-10-06T20:21:43.201Z" },
-    { url = "https://files.pythonhosted.org/packages/de/46/21ea696b21f1d6d1efec8639c204bdf20fde8bafb351e1355c72c5d7de52/tiktoken-0.12.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:6e227c7f96925003487c33b1b32265fad2fbcec2b7cf4817afb76d416f40f6bb", size = 1051565, upload-time = "2025-10-06T20:21:44.566Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/d9/35c5d2d9e22bb2a5f74ba48266fb56c63d76ae6f66e02feb628671c0283e/tiktoken-0.12.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c06cf0fcc24c2cb2adb5e185c7082a82cba29c17575e828518c2f11a01f445aa", size = 995284, upload-time = "2025-10-06T20:21:45.622Z" },
-    { url = "https://files.pythonhosted.org/packages/01/84/961106c37b8e49b9fdcf33fe007bb3a8fdcc380c528b20cc7fbba80578b8/tiktoken-0.12.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:f18f249b041851954217e9fd8e5c00b024ab2315ffda5ed77665a05fa91f42dc", size = 1129201, upload-time = "2025-10-06T20:21:47.074Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/d0/3d9275198e067f8b65076a68894bb52fd253875f3644f0a321a720277b8a/tiktoken-0.12.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:47a5bc270b8c3db00bb46ece01ef34ad050e364b51d406b6f9730b64ac28eded", size = 1152444, upload-time = "2025-10-06T20:21:48.139Z" },
-    { url = "https://files.pythonhosted.org/packages/78/db/a58e09687c1698a7c592e1038e01c206569b86a0377828d51635561f8ebf/tiktoken-0.12.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:508fa71810c0efdcd1b898fda574889ee62852989f7c1667414736bcb2b9a4bd", size = 1195080, upload-time = "2025-10-06T20:21:49.246Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/1b/a9e4d2bf91d515c0f74afc526fd773a812232dd6cda33ebea7f531202325/tiktoken-0.12.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a1af81a6c44f008cba48494089dd98cccb8b313f55e961a52f5b222d1e507967", size = 1255240, upload-time = "2025-10-06T20:21:50.274Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/15/963819345f1b1fb0809070a79e9dd96938d4ca41297367d471733e79c76c/tiktoken-0.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:3e68e3e593637b53e56f7237be560f7a394451cb8c11079755e80ae64b9e6def", size = 879422, upload-time = "2025-10-06T20:21:51.734Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/85/be65d39d6b647c79800fd9d29241d081d4eeb06271f383bb87200d74cf76/tiktoken-0.12.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b97f74aca0d78a1ff21b8cd9e9925714c15a9236d6ceacf5c7327c117e6e21e8", size = 1050728, upload-time = "2025-10-06T20:21:52.756Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/42/6573e9129bc55c9bf7300b3a35bef2c6b9117018acca0dc760ac2d93dffe/tiktoken-0.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2b90f5ad190a4bb7c3eb30c5fa32e1e182ca1ca79f05e49b448438c3e225a49b", size = 994049, upload-time = "2025-10-06T20:21:53.782Z" },
-    { url = "https://files.pythonhosted.org/packages/66/c5/ed88504d2f4a5fd6856990b230b56d85a777feab84e6129af0822f5d0f70/tiktoken-0.12.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:65b26c7a780e2139e73acc193e5c63ac754021f160df919add909c1492c0fb37", size = 1129008, upload-time = "2025-10-06T20:21:54.832Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/90/3dae6cc5436137ebd38944d396b5849e167896fc2073da643a49f372dc4f/tiktoken-0.12.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:edde1ec917dfd21c1f2f8046b86348b0f54a2c0547f68149d8600859598769ad", size = 1152665, upload-time = "2025-10-06T20:21:56.129Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/fe/26df24ce53ffde419a42f5f53d755b995c9318908288c17ec3f3448313a3/tiktoken-0.12.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:35a2f8ddd3824608b3d650a000c1ef71f730d0c56486845705a8248da00f9fe5", size = 1194230, upload-time = "2025-10-06T20:21:57.546Z" },
-    { url = "https://files.pythonhosted.org/packages/20/cc/b064cae1a0e9fac84b0d2c46b89f4e57051a5f41324e385d10225a984c24/tiktoken-0.12.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:83d16643edb7fa2c99eff2ab7733508aae1eebb03d5dfc46f5565862810f24e3", size = 1254688, upload-time = "2025-10-06T20:21:58.619Z" },
-    { url = "https://files.pythonhosted.org/packages/81/10/b8523105c590c5b8349f2587e2fdfe51a69544bd5a76295fc20f2374f470/tiktoken-0.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffc5288f34a8bc02e1ea7047b8d041104791d2ddbf42d1e5fa07822cbffe16bd", size = 878694, upload-time = "2025-10-06T20:21:59.876Z" },
-    { url = "https://files.pythonhosted.org/packages/00/61/441588ee21e6b5cdf59d6870f86beb9789e532ee9718c251b391b70c68d6/tiktoken-0.12.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:775c2c55de2310cc1bc9a3ad8826761cbdc87770e586fd7b6da7d4589e13dab3", size = 1050802, upload-time = "2025-10-06T20:22:00.96Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/05/dcf94486d5c5c8d34496abe271ac76c5b785507c8eae71b3708f1ad9b45a/tiktoken-0.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a01b12f69052fbe4b080a2cfb867c4de12c704b56178edf1d1d7b273561db160", size = 993995, upload-time = "2025-10-06T20:22:02.788Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/70/5163fe5359b943f8db9946b62f19be2305de8c3d78a16f629d4165e2f40e/tiktoken-0.12.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:01d99484dc93b129cd0964f9d34eee953f2737301f18b3c7257bf368d7615baa", size = 1128948, upload-time = "2025-10-06T20:22:03.814Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/da/c028aa0babf77315e1cef357d4d768800c5f8a6de04d0eac0f377cb619fa/tiktoken-0.12.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:4a1a4fcd021f022bfc81904a911d3df0f6543b9e7627b51411da75ff2fe7a1be", size = 1151986, upload-time = "2025-10-06T20:22:05.173Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/5a/886b108b766aa53e295f7216b509be95eb7d60b166049ce2c58416b25f2a/tiktoken-0.12.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:981a81e39812d57031efdc9ec59fa32b2a5a5524d20d4776574c4b4bd2e9014a", size = 1194222, upload-time = "2025-10-06T20:22:06.265Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/f8/4db272048397636ac7a078d22773dd2795b1becee7bc4922fe6207288d57/tiktoken-0.12.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9baf52f84a3f42eef3ff4e754a0db79a13a27921b457ca9832cf944c6be4f8f3", size = 1255097, upload-time = "2025-10-06T20:22:07.403Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/32/45d02e2e0ea2be3a9ed22afc47d93741247e75018aac967b713b2941f8ea/tiktoken-0.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:b8a0cd0c789a61f31bf44851defbd609e8dd1e2c8589c614cc1060940ef1f697", size = 879117, upload-time = "2025-10-06T20:22:08.418Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/76/994fc868f88e016e6d05b0da5ac24582a14c47893f4474c3e9744283f1d5/tiktoken-0.12.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:d5f89ea5680066b68bcb797ae85219c72916c922ef0fcdd3480c7d2315ffff16", size = 1050309, upload-time = "2025-10-06T20:22:10.939Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/b8/57ef1456504c43a849821920d582a738a461b76a047f352f18c0b26c6516/tiktoken-0.12.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b4e7ed1c6a7a8a60a3230965bdedba8cc58f68926b835e519341413370e0399a", size = 993712, upload-time = "2025-10-06T20:22:12.115Z" },
-    { url = "https://files.pythonhosted.org/packages/72/90/13da56f664286ffbae9dbcfadcc625439142675845baa62715e49b87b68b/tiktoken-0.12.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:fc530a28591a2d74bce821d10b418b26a094bf33839e69042a6e86ddb7a7fb27", size = 1128725, upload-time = "2025-10-06T20:22:13.541Z" },
-    { url = "https://files.pythonhosted.org/packages/05/df/4f80030d44682235bdaecd7346c90f67ae87ec8f3df4a3442cb53834f7e4/tiktoken-0.12.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:06a9f4f49884139013b138920a4c393aa6556b2f8f536345f11819389c703ebb", size = 1151875, upload-time = "2025-10-06T20:22:14.559Z" },
-    { url = "https://files.pythonhosted.org/packages/22/1f/ae535223a8c4ef4c0c1192e3f9b82da660be9eb66b9279e95c99288e9dab/tiktoken-0.12.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:04f0e6a985d95913cabc96a741c5ffec525a2c72e9df086ff17ebe35985c800e", size = 1194451, upload-time = "2025-10-06T20:22:15.545Z" },
-    { url = "https://files.pythonhosted.org/packages/78/a7/f8ead382fce0243cb625c4f266e66c27f65ae65ee9e77f59ea1653b6d730/tiktoken-0.12.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ee8f9ae00c41770b5f9b0bb1235474768884ae157de3beb5439ca0fd70f3e25", size = 1253794, upload-time = "2025-10-06T20:22:16.624Z" },
-    { url = "https://files.pythonhosted.org/packages/93/e0/6cc82a562bc6365785a3ff0af27a2a092d57c47d7a81d9e2295d8c36f011/tiktoken-0.12.0-cp313-cp313t-win_amd64.whl", hash = "sha256:dc2dd125a62cb2b3d858484d6c614d136b5b848976794edfb63688d539b8b93f", size = 878777, upload-time = "2025-10-06T20:22:18.036Z" },
-    { url = "https://files.pythonhosted.org/packages/72/05/3abc1db5d2c9aadc4d2c76fa5640134e475e58d9fbb82b5c535dc0de9b01/tiktoken-0.12.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:a90388128df3b3abeb2bfd1895b0681412a8d7dc644142519e6f0a97c2111646", size = 1050188, upload-time = "2025-10-06T20:22:19.563Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/7b/50c2f060412202d6c95f32b20755c7a6273543b125c0985d6fa9465105af/tiktoken-0.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:da900aa0ad52247d8794e307d6446bd3cdea8e192769b56276695d34d2c9aa88", size = 993978, upload-time = "2025-10-06T20:22:20.702Z" },
-    { url = "https://files.pythonhosted.org/packages/14/27/bf795595a2b897e271771cd31cb847d479073497344c637966bdf2853da1/tiktoken-0.12.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:285ba9d73ea0d6171e7f9407039a290ca77efcdb026be7769dccc01d2c8d7fff", size = 1129271, upload-time = "2025-10-06T20:22:22.06Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/de/9341a6d7a8f1b448573bbf3425fa57669ac58258a667eb48a25dfe916d70/tiktoken-0.12.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:d186a5c60c6a0213f04a7a802264083dea1bbde92a2d4c7069e1a56630aef830", size = 1151216, upload-time = "2025-10-06T20:22:23.085Z" },
-    { url = "https://files.pythonhosted.org/packages/75/0d/881866647b8d1be4d67cb24e50d0c26f9f807f994aa1510cb9ba2fe5f612/tiktoken-0.12.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:604831189bd05480f2b885ecd2d1986dc7686f609de48208ebbbddeea071fc0b", size = 1194860, upload-time = "2025-10-06T20:22:24.602Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/1e/b651ec3059474dab649b8d5b69f5c65cd8fcd8918568c1935bd4136c9392/tiktoken-0.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8f317e8530bb3a222547b85a58583238c8f74fd7a7408305f9f63246d1a0958b", size = 1254567, upload-time = "2025-10-06T20:22:25.671Z" },
-    { url = "https://files.pythonhosted.org/packages/80/57/ce64fd16ac390fafde001268c364d559447ba09b509181b2808622420eec/tiktoken-0.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:399c3dd672a6406719d84442299a490420b458c44d3ae65516302a99675888f3", size = 921067, upload-time = "2025-10-06T20:22:26.753Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/a4/72eed53e8976a099539cdd5eb36f241987212c29629d0a52c305173e0a68/tiktoken-0.12.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:c2c714c72bc00a38ca969dae79e8266ddec999c7ceccd603cc4f0d04ccd76365", size = 1050473, upload-time = "2025-10-06T20:22:27.775Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/d7/0110b8f54c008466b19672c615f2168896b83706a6611ba6e47313dbc6e9/tiktoken-0.12.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cbb9a3ba275165a2cb0f9a83f5d7025afe6b9d0ab01a22b50f0e74fee2ad253e", size = 993855, upload-time = "2025-10-06T20:22:28.799Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/77/4f268c41a3957c418b084dd576ea2fad2e95da0d8e1ab705372892c2ca22/tiktoken-0.12.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:dfdfaa5ffff8993a3af94d1125870b1d27aed7cb97aa7eb8c1cefdbc87dbee63", size = 1129022, upload-time = "2025-10-06T20:22:29.981Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/2b/fc46c90fe5028bd094cd6ee25a7db321cb91d45dc87531e2bdbb26b4867a/tiktoken-0.12.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:584c3ad3d0c74f5269906eb8a659c8bfc6144a52895d9261cdaf90a0ae5f4de0", size = 1150736, upload-time = "2025-10-06T20:22:30.996Z" },
-    { url = "https://files.pythonhosted.org/packages/28/c0/3c7a39ff68022ddfd7d93f3337ad90389a342f761c4d71de99a3ccc57857/tiktoken-0.12.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:54c891b416a0e36b8e2045b12b33dd66fb34a4fe7965565f1b482da50da3e86a", size = 1194908, upload-time = "2025-10-06T20:22:32.073Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/0d/c1ad6f4016a3968c048545f5d9b8ffebf577774b2ede3e2e352553b685fe/tiktoken-0.12.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5edb8743b88d5be814b1a8a8854494719080c28faaa1ccbef02e87354fe71ef0", size = 1253706, upload-time = "2025-10-06T20:22:33.385Z" },
-    { url = "https://files.pythonhosted.org/packages/af/df/c7891ef9d2712ad774777271d39fdef63941ffba0a9d59b7ad1fd2765e57/tiktoken-0.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f61c0aea5565ac82e2ec50a05e02a6c44734e91b51c10510b084ea1b8e633a71", size = 920667, upload-time = "2025-10-06T20:22:34.444Z" },
 ]
 
 [[package]]


### PR DESCRIPTION

## Summary

Adds SparkStandaloneExecutor to the Apache Spark provider — a new Airflow executor that submits every task to a Spark Standalone cluster via the REST Submission API, with no changes required to any DAG.


## Motivation
Running Airflow tasks on Spark today requires every DAG author to use SparkSubmitOperator: a separate operator per task, a standalone Python application file deployed to the cluster, and a Spark connection configured by the platform team. This couples infrastructure decisions to DAG code — moving a pipeline to Spark means rewriting it.

KubernetesExecutor solved the equivalent problem for Kubernetes in 2019: configure the executor once, and every task runs in a pod. SparkSubmitOperator is to KubernetesExecutor what KubernetesPodOperator was before KubernetesExecutor existed.

Spark has never had that moment. This PR is that moment.

## What This Does

1. Adds `SparkStandaloneExecutor`, which implements BaseExecutor and uses the Spark REST Submission API (`/v1/submissions/create`, `/v1/submissions/status/{id}`) to submit and poll Airflow tasks as Spark driver applications.
Each task is submitted as a JVM driver application (`AirflowDriverLauncher.jar` — a thin Java shim that spawns python3 `airflow_task_runner.py` as a subprocess). This works around Spark Standalone's explicit lack of support for Python appResource in cluster deploy mode.

2. The task runner calls `airflow.sdk.execution_time.execute_workload `— the same entry point used by KubernetesExecutor — so full AIP-72 task execution, heartbeating, XCom, and callbacks work out of the box.

3. Tasks that call `SparkSession.builder.getOrCreate()` receive a live session for free, because they run inside a Spark driver process on a worker node.

4. Remote logging via S3-compatible storage (`MinIO` in the dev setup) is supported, so task logs are readable in the Airflow UI without a serve-logs daemon on worker containers.

5. Per-task Spark resource overrides via `executor_config={"spark_properties": {...}}`.

## Who Can Use This

1. Data engineering teams running Spark Standalone clusters (on-premises or bare-metal cloud) who want to use Airflow for orchestration without restructuring every DAG.

2. Platform teams who want to move an entire Airflow deployment onto Spark with a single config change.

3. Teams that evaluated KubernetesExecutor but cannot adopt it because their compute is Spark, not Kubernetes.

NOTE: This is not relevant for YARN or Kubernetes-managed Spark — use SparkKubernetesOperator or Livy for those.


Demo recording:

```
Shareable link: https://astronomer.zoom.us/rec/share/cWHNQhd78gaZjGG0_CBTRT42oHN3ucYpHYDir7Qgld5aQSBn4kaYdhS3Wwp8o7f2.mcn1dsHurdl7VEQr
Passcode: W^w=#5Pz
```


