### PR TITLE
Simplify coordinator-related names

### DIFF
--- a/airflow-core/src/airflow/dag_processing/manager.py
+++ b/airflow-core/src/airflow/dag_processing/manager.py
@@ -803,7 +803,7 @@ class DagFileProcessorManager(LoggingMixin):
         from airflow.providers_manager import ProvidersManager
 
         extensions: list[str] = []
-        for coordinator_cls in ProvidersManager().runtime_coordinators:
+        for coordinator_cls in ProvidersManager().coordinators:
             extensions.append(coordinator_cls.file_extension)
         self._runtime_file_extensions = tuple(extensions)
         return self._runtime_file_extensions

--- a/airflow-core/src/airflow/dag_processing/processor.py
+++ b/airflow-core/src/airflow/dag_processing/processor.py
@@ -76,8 +76,6 @@ from airflow.utils.file import iter_airflow_imports
 from airflow.utils.state import TaskInstanceState
 
 if TYPE_CHECKING:
-    from socket import socket
-
     from structlog.typing import FilteringBoundLogger
 
     from airflow.api_fastapi.execution_api.app import InProcessExecutionAPI
@@ -86,6 +84,7 @@ if TYPE_CHECKING:
     from airflow.sdk.definitions.context import Context
     from airflow.sdk.definitions.dag import DAG
     from airflow.sdk.definitions.mappedoperator import MappedOperator
+    from airflow.sdk.execution_time.supervisor import SelectorCallback
     from airflow.typing_compat import Self
 
 
@@ -589,7 +588,7 @@ class DagFileProcessorProcess(WatchedSubprocess):
         """
         from airflow.providers_manager import ProvidersManager
 
-        for coordinator_cls in ProvidersManager().runtime_coordinators:
+        for coordinator_cls in ProvidersManager().coordinators:
             try:
                 log.debug(
                     "Checking runtime coordinator %s for file %s",
@@ -645,7 +644,7 @@ class DagFileProcessorProcess(WatchedSubprocess):
 
     def _create_log_forwarder(
         self, loggers: tuple[FilteringBoundLogger, ...], name: str, log_level: int = logging.INFO
-    ) -> Callable[[socket], bool]:
+    ) -> SelectorCallback:
         return super()._create_log_forwarder(loggers, name.replace("task.", "dag_processor.", 1), log_level)
 
     def _handle_request(self, msg: ToManager, log: FilteringBoundLogger, req_id: int) -> None:

--- a/airflow-core/src/airflow/models/dagcode.py
+++ b/airflow-core/src/airflow/models/dagcode.py
@@ -122,7 +122,7 @@ class DagCode(Base):
         # Try from runtime coordinator first (classes are pre-loaded by ProvidersManager)
         from airflow.providers_manager import ProvidersManager
 
-        for coordinator_cls in ProvidersManager().runtime_coordinators:
+        for coordinator_cls in ProvidersManager().coordinators:
             # TODO: Perhaps the `can_handle_dag_file` interface should just accept `path` only?
             # Or maybe we can have different granularity for this. that 1 with bundle + path, another with just path
             if coordinator_cls.can_handle_dag_file("", fileloc):

--- a/airflow-core/src/airflow/provider.yaml.schema.json
+++ b/airflow-core/src/airflow/provider.yaml.schema.json
@@ -624,9 +624,9 @@
                 }
             }
         },
-        "runtime-coordinators": {
+        "coordinators": {
             "type": "array",
-            "description": "Runtime Coordinator class names (BaseRuntimeCoordinator subclasses)",
+            "description": "Runtime Coordinator class names (BaseCoordinator subclasses)",
             "items": {
                 "type": "string"
             }

--- a/airflow-core/src/airflow/provider_info.schema.json
+++ b/airflow-core/src/airflow/provider_info.schema.json
@@ -447,9 +447,9 @@
                 }
             }
         },
-        "runtime-coordinators": {
+        "coordinators": {
             "type": "array",
-            "description": "Runtime Coordinator class names (BaseRuntimeCoordinator subclasses)",
+            "description": "Runtime Coordinator class names (BaseCoordinator subclasses)",
             "items": {
                 "type": "string"
             }

--- a/airflow-core/src/airflow/providers_manager.py
+++ b/airflow-core/src/airflow/providers_manager.py
@@ -41,7 +41,7 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 
 if TYPE_CHECKING:
     from airflow.cli.cli_config import CLICommand
-    from airflow.sdk.execution_time.coordinator import BaseRuntimeCoordinator
+    from airflow.sdk.execution_time.coordinator import BaseCoordinator
 
 log = logging.getLogger(__name__)
 
@@ -449,7 +449,7 @@ class ProvidersManager(LoggingMixin):
         )
         # Set of plugins contained in providers
         self._plugins_set: set[PluginInfo] = set()
-        self._runtime_coordinators: list[type[BaseRuntimeCoordinator]] = []
+        self._coordinators: list[type[BaseCoordinator]] = []
         self._init_airflow_core_hooks()
 
         self._runtime_manager = None
@@ -627,11 +627,11 @@ class ProvidersManager(LoggingMixin):
         self.initialize_providers_list()
         self._discover_config()
 
-    @provider_info_cache("runtime_coordinators")
-    def initialize_providers_runtime_coordinators(self):
+    @provider_info_cache("coordinators")
+    def initialize_providers_coordinators(self):
         """Lazy initialization of providers runtime coordinators."""
         self.initialize_providers_list()
-        self._discover_runtime_coordinators()
+        self._discover_coordinators()
 
     @provider_info_cache("plugins")
     def initialize_providers_plugins(self):
@@ -1288,18 +1288,18 @@ class ProvidersManager(LoggingMixin):
             if provider.data.get("config"):
                 self._provider_configs[provider_package] = provider.data.get("config")  # type: ignore[assignment]
 
-    def _discover_runtime_coordinators(self) -> None:
-        """Retrieve and pre-load all runtime coordinators defined in the providers."""
+    def _discover_coordinators(self) -> None:
+        """Retrieve and pre-load all coordinators defined in the providers."""
         seen: set[str] = set()
         for provider_package, provider in self._provider_dict.items():
-            for coordinator_class_path in provider.data.get("runtime-coordinators", []):
+            for coordinator_class_path in provider.data.get("coordinators", []):
                 if coordinator_class_path in seen:
                     continue
                 coordinator_cls = _correctness_check(provider_package, coordinator_class_path, provider)
                 if coordinator_cls:
                     seen.add(coordinator_class_path)
-                    self._runtime_coordinators.append(coordinator_cls)
-        self._runtime_coordinators = sorted(self._runtime_coordinators, key=lambda c: c.__qualname__)
+                    self._coordinators.append(coordinator_cls)
+        self._coordinators = sorted(self._coordinators, key=lambda c: c.__qualname__)
 
     def _discover_plugins(self) -> None:
         """Retrieve all plugins defined in the providers."""
@@ -1499,10 +1499,10 @@ class ProvidersManager(LoggingMixin):
         return sorted(self._db_manager_class_name_set)
 
     @property
-    def runtime_coordinators(self) -> list[type[BaseRuntimeCoordinator]]:
-        """Returns pre-loaded runtime coordinator classes available in providers."""
-        self.initialize_providers_runtime_coordinators()
-        return self._runtime_coordinators
+    def coordinators(self) -> list[type[BaseCoordinator]]:
+        """Returns pre-loaded coordinator classes available in providers."""
+        self.initialize_providers_coordinators()
+        return self._coordinators
 
     @property
     def filesystem_module_names(self) -> list[str]:
@@ -1575,7 +1575,7 @@ class ProvidersManager(LoggingMixin):
         self._trigger_info_set.clear()
         self._notification_info_set.clear()
         self._plugins_set.clear()
-        self._runtime_coordinators.clear()
+        self._coordinators.clear()
         self._cli_command_functions_set.clear()
         self._cli_command_provider_name_set.clear()
 

--- a/airflow-core/tests/unit/always/test_providers_manager.py
+++ b/airflow-core/tests/unit/always/test_providers_manager.py
@@ -259,7 +259,7 @@ class TestProviderManager:
         assert dialect_class_names == ["default", "mssql", "postgresql"]
 
     @patch("airflow.providers_manager.import_string")
-    def test_runtime_coordinators(self, mock_import_string):
+    def test_coordinators(self, mock_import_string):
         class ACoordinator:
             pass
 
@@ -275,7 +275,7 @@ class TestProviderManager:
         providers_manager._provider_dict["apache-airflow-providers-sdk-java"] = ProviderInfo(
             version="0.0.1",
             data={
-                "runtime-coordinators": [
+                "coordinators": [
                     "airflow.providers.sdk.java.coordinator.ZCoordinator",
                     "airflow.providers.sdk.java.coordinator.ACoordinator",
                     "airflow.providers.sdk.java.coordinator.ZCoordinator",
@@ -284,7 +284,7 @@ class TestProviderManager:
         )
 
         with patch.object(providers_manager, "initialize_providers_list"):
-            assert providers_manager.runtime_coordinators == [ACoordinator, ZCoordinator]
+            assert providers_manager.coordinators == [ACoordinator, ZCoordinator]
 
 
 class TestWithoutCheckProviderManager:

--- a/providers/sdk/java/provider.yaml
+++ b/providers/sdk/java/provider.yaml
@@ -54,5 +54,5 @@ config:
         example: ~/airflow/java-bundles
         default: ""
 
-runtime-coordinators:
-  - airflow.providers.sdk.java.coordinator.JavaRuntimeCoordinator
+coordinators:
+  - airflow.providers.sdk.java.coordinator.JavaCoordinator

--- a/providers/sdk/java/src/airflow/providers/sdk/java/coordinator.py
+++ b/providers/sdk/java/src/airflow/providers/sdk/java/coordinator.py
@@ -26,16 +26,16 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from airflow.providers.sdk.java.bundle_scanner import BundleScanner, read_dag_code
-from airflow.sdk.execution_time.coordinator import BaseRuntimeCoordinator
+from airflow.sdk.execution_time.coordinator import BaseCoordinator
 
 if TYPE_CHECKING:
     from airflow.sdk.api.datamodels._generated import BundleInfo, TaskInstance
 
 
-class JavaRuntimeCoordinator(BaseRuntimeCoordinator):
+class JavaCoordinator(BaseCoordinator):
     """Coordinator that launches a JVM subprocess for DAG parsing and task execution."""
 
-    runtime_name = "java"
+    sdk = "java"
     file_extension = ".jar"
 
     @classmethod
@@ -54,7 +54,7 @@ class JavaRuntimeCoordinator(BaseRuntimeCoordinator):
         return code
 
     @classmethod
-    def dag_parsing_runtime_cmd(
+    def dag_parsing_cmd(
         cls,
         *,
         dag_file_path: str,
@@ -80,7 +80,7 @@ class JavaRuntimeCoordinator(BaseRuntimeCoordinator):
         ]
 
     @classmethod
-    def task_execution_runtime_cmd(
+    def task_execution_cmd(
         cls,
         *,
         what: TaskInstance,

--- a/providers/sdk/java/src/airflow/providers/sdk/java/get_provider_info.py
+++ b/providers/sdk/java/src/airflow/providers/sdk/java/get_provider_info.py
@@ -43,5 +43,5 @@ def get_provider_info():
                 },
             }
         },
-        "runtime-coordinators": ["airflow.providers.sdk.java.coordinator.JavaRuntimeCoordinator"],
+        "coordinators": ["airflow.providers.sdk.java.coordinator.JavaCoordinator"],
     }

--- a/providers/sdk/java/tests/unit/sdk/java/test_java_provider.py
+++ b/providers/sdk/java/tests/unit/sdk/java/test_java_provider.py
@@ -17,7 +17,7 @@
 # under the License.
 from __future__ import annotations
 
-from airflow.providers.sdk.java.coordinator import JavaRuntimeCoordinator
+from airflow.providers.sdk.java.coordinator import JavaCoordinator
 from airflow.providers.sdk.java.get_provider_info import get_provider_info
 
 
@@ -33,11 +33,11 @@ def test_get_provider_info_exposes_java_runtime_components():
                 "tags": ["software"],
             }
         ],
-        "runtime-coordinators": [
-            "airflow.providers.sdk.java.coordinator.JavaRuntimeCoordinator",
+        "coordinators": [
+            "airflow.providers.sdk.java.coordinator.JavaCoordinator",
         ],
     }
 
 
 def test_java_provider_entrypoints_are_importable():
-    assert JavaRuntimeCoordinator.runtime_name == "java"
+    assert JavaCoordinator.sdk == "java"

--- a/task-sdk/.pre-commit-config.yaml
+++ b/task-sdk/.pre-commit-config.yaml
@@ -43,6 +43,7 @@ repos:
           ^src/airflow/sdk/definitions/deadline\.py$|
           ^src/airflow/sdk/definitions/dag\.py$|
           ^src/airflow/sdk/definitions/_internal/types\.py$|
+          ^src/airflow/sdk/execution_time/coordinator\.py$|
           ^src/airflow/sdk/execution_time/execute_workload\.py$|
           ^src/airflow/sdk/execution_time/secrets_masker\.py$|
           ^src/airflow/sdk/execution_time/callback_supervisor\.py$|

--- a/task-sdk/src/airflow/sdk/execution_time/coordinator.py
+++ b/task-sdk/src/airflow/sdk/execution_time/coordinator.py
@@ -18,15 +18,15 @@
 """
 Runtime coordinator for non-Python DAG file processing and task execution.
 
-Provides :class:`BaseRuntimeCoordinator`, the base class for
+Provides :class:`BaseCoordinator`, the base class for
 SDK-specific coordinators that bridge subprocess I/O between the
 Airflow supervisor and an external-SDK runtime (Java, Go, Rust, etc.).
 
-The coordinator's :meth:`~BaseRuntimeCoordinator.run_dag_parsing` method
+The coordinator's :meth:`~BaseCoordinator.run_dag_parsing` method
 handles the full lifecycle:
 
 1. Creates TCP servers for comm and logs channels.
-2. Calls :meth:`~BaseRuntimeCoordinator.dag_parsing_runtime_cmd` (provided
+2. Calls :meth:`~BaseCoordinator.dag_parsing_cmd` (provided
    by the subclass) to obtain the subprocess command.
 3. Spawns the subprocess and accepts TCP connections from it.
 4. Runs a selector-based bridge that transparently forwards bytes
@@ -50,6 +50,7 @@ from typing import TYPE_CHECKING, NamedTuple
 
 if TYPE_CHECKING:
     from structlog.typing import FilteringBoundLogger
+    from typing_extensions import Self
 
     from airflow.sdk._shared.workloads import TaskInstanceDTO
     from airflow.sdk.api.datamodels._generated import BundleInfo
@@ -166,23 +167,23 @@ def _bridge(
             sock.close()
 
 
-class BaseRuntimeCoordinator:
+class BaseCoordinator:
     """
     Base coordinator for runtime-specific DAG file processing and task execution.
 
     Providers register subclasses in their ``provider.yaml`` under
-    ``runtime-coordinators``.  Both :class:`ProvidersManager` (airflow-core)
+    ``coordinators``.  Both :class:`ProvidersManager` (airflow-core)
     and :class:`ProvidersManagerTaskRuntime` (task-sdk) discover registered
     coordinators through this single extension point.
 
     Subclasses represent a specific SDK runtime (Java, Go, etc.) and
     only need to implement :meth:`can_handle_dag_file`,
-    :meth:`dag_parsing_runtime_cmd` and :meth:`task_execution_runtime_cmd`.
+    :meth:`dag_parsing_cmd` and :meth:`task_execution_cmd`.
     The base class owns the entire bridge lifecycle: TCP servers,
     subprocess management, selector-based I/O loop, and cleanup.
     """
 
-    runtime_name: str
+    sdk: str
     file_extension: str
 
     class DagParsingInfo(NamedTuple):
@@ -233,7 +234,7 @@ class BaseRuntimeCoordinator:
         raise NotImplementedError
 
     @classmethod
-    def dag_parsing_runtime_cmd(
+    def dag_parsing_cmd(
         cls,
         *,
         dag_file_path: str,
@@ -257,7 +258,7 @@ class BaseRuntimeCoordinator:
         raise NotImplementedError
 
     @classmethod
-    def task_execution_runtime_cmd(
+    def task_execution_cmd(
         cls,
         *,
         what: TaskInstanceDTO,
@@ -320,7 +321,7 @@ class BaseRuntimeCoordinator:
         bidirectional comms socket to the supervisor.  The method:
 
         1. Creates TCP servers for comm and logs.
-        2. Calls :meth:`dag_parsing_runtime_cmd` or :meth:`task_execution_runtime_cmd` to get the command.
+        2. Calls :meth:`dag_parsing_cmd` or :meth:`task_execution_cmd` to get the command.
         3. Spawns the subprocess with ``stdin=/dev/null`` and stderr
            captured via a socketpair.
         4. Runs the selector-based bridge until the subprocess exits.
@@ -342,7 +343,7 @@ class BaseRuntimeCoordinator:
         log = structlog.get_logger(logger_name="task")
         log.info(
             "Starting runtime subprocess",
-            runtime=cls.runtime_name,
+            sdk=cls.sdk,
             mode=entrypoint_info.mode,
         )
 
@@ -365,7 +366,7 @@ class BaseRuntimeCoordinator:
         bundle_version_lock: contextlib.AbstractContextManager = contextlib.nullcontext()
 
         if isinstance(entrypoint_info, cls.DagParsingInfo):
-            cmd = cls.dag_parsing_runtime_cmd(
+            cmd = cls.dag_parsing_cmd(
                 dag_file_path=entrypoint_info.dag_file_path,
                 bundle_name=entrypoint_info.bundle_name,
                 bundle_path=entrypoint_info.bundle_path,
@@ -373,22 +374,16 @@ class BaseRuntimeCoordinator:
                 logs_addr=logs_addr,
             )
         elif isinstance(entrypoint_info, cls.TaskExecutionInfo):
-            from pathlib import Path
-
-            # import from core now will raise static check error from `check-core-imports` check
-            # We should support ignore label for the above static check
-            # directly commit for now
             from airflow.dag_processing.bundles.base import BundleVersionLock
             from airflow.sdk.execution_time.task_runner import resolve_bundle
 
             bundle_instance = resolve_bundle(entrypoint_info.bundle_info, log)
-            resolved_bundle_path = str(bundle_instance.path)
-            resolved_dag_file_path = os.fspath(Path(bundle_instance.path, entrypoint_info.dag_rel_path))
+            resolved_dag_file_path = bundle_instance.path / entrypoint_info.dag_rel_path
 
-            cmd = cls.task_execution_runtime_cmd(
+            cmd = cls.task_execution_cmd(
                 what=entrypoint_info.what,
-                dag_file_path=resolved_dag_file_path,
-                bundle_path=resolved_bundle_path,
+                dag_file_path=os.fspath(resolved_dag_file_path),
+                bundle_path=os.fspath(bundle_instance.path),
                 bundle_info=entrypoint_info.bundle_info,
                 comm_addr=comm_addr,
                 logs_addr=logs_addr,
@@ -429,16 +424,16 @@ class BaseRuntimeCoordinator:
             _bridge(supervisor_comm, runtime_comm, runtime_logs, read_stderr, proc, log)
 
 
-class QueueToRuntimeCoordinatorMapper:
+class QueueToCoordinatorMapper:
     """
-    Map queue names to runtime coordinator names.
+    Map queue names to coordinator names.
 
     Users often use queues as environment/isolation identifiers (e.g. ``"java-11"``,
     ``"java-12"``).  This mapper lets them reuse existing queue assignments to route
-    tasks to the correct runtime coordinator.
+    tasks to the correct coordinator.
 
     The mapping is read from the ``[sdk] queue_to_sdk``
-    configuration option, which is a JSON dict of ``queue_name -> runtime_name``.
+    configuration option, which is a JSON dict of ``queue -> sdk``.
 
     Example configuration::
 
@@ -450,7 +445,7 @@ class QueueToRuntimeCoordinatorMapper:
         self._mapping = mapping
 
     @classmethod
-    def from_config(cls) -> QueueToRuntimeCoordinatorMapper:
+    def from_config(cls) -> Self:
         """Load the queue-to-runtime mapping from airflow configuration."""
         from airflow.sdk.configuration import conf
 
@@ -464,4 +459,4 @@ class QueueToRuntimeCoordinatorMapper:
         return self._mapping.get(queue)
 
 
-__all__ = ["BaseRuntimeCoordinator", "QueueToRuntimeCoordinatorMapper"]
+__all__ = ["BaseCoordinator", "QueueToCoordinatorMapper"]

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1887,25 +1887,24 @@ def _resolve_runtime_entrypoint(startup_details: StartupDetails, log: Logger) ->
     """
     import functools
 
-    from airflow.sdk.execution_time.coordinator import QueueToRuntimeCoordinatorMapper
+    from airflow.sdk.execution_time.coordinator import QueueToCoordinatorMapper
     from airflow.sdk.providers_manager_runtime import ProvidersManagerTaskRuntime
 
-    coordinators = ProvidersManagerTaskRuntime().runtime_coordinators
+    coordinators = ProvidersManagerTaskRuntime().coordinators
 
     # Step 1: queue-to-runtime mapping.
     queue = startup_details.ti.queue
-    runtime_name = QueueToRuntimeCoordinatorMapper.from_config().resolve(queue)
-    if runtime_name is not None:
+    if (sdk := QueueToCoordinatorMapper.from_config().resolve(queue)) is not None:
         for coordinator_cls in coordinators:
             if not hasattr(coordinator_cls, "run_task_execution"):
                 continue
-            if getattr(coordinator_cls, "runtime_name", None) != runtime_name:
+            if getattr(coordinator_cls, "sdk", None) != sdk:
                 continue
 
             log.debug(
-                "Resolved runtime-specific entrypoint for task via queue mapping",
+                "Resolved sdk-specific entrypoint for task via queue mapping",
                 coordinator=coordinator_cls,
-                runtime=runtime_name,
+                sdk=sdk,
                 queue=queue,
                 task_id=startup_details.ti.task_id,
             )
@@ -1918,8 +1917,8 @@ def _resolve_runtime_entrypoint(startup_details: StartupDetails, log: Logger) ->
             )
 
         log.warning(
-            "No runtime coordinator found for runtime",
-            runtime=runtime_name,
+            "No coordinator found for sdk",
+            sdk=sdk,
             queue=queue,
             task_id=startup_details.ti.task_id,
         )
@@ -1938,7 +1937,7 @@ def _resolve_runtime_entrypoint(startup_details: StartupDetails, log: Logger) ->
         log.debug(
             "Resolved runtime-specific entrypoint for task via DAG file extension",
             coordinator=coordinator_cls,
-            runtime=getattr(coordinator_cls, "runtime_name", None),
+            sdk=getattr(coordinator_cls, "sdk", None),
             dag_rel_path=dag_rel_path,
             task_id=startup_details.ti.task_id,
         )

--- a/task-sdk/src/airflow/sdk/providers_manager_runtime.py
+++ b/task-sdk/src/airflow/sdk/providers_manager_runtime.py
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
     from airflow.sdk import BaseHook
     from airflow.sdk.bases.decorator import TaskDecorator
     from airflow.sdk.definitions.asset import Asset
-    from airflow.sdk.execution_time.coordinator import BaseRuntimeCoordinator
+    from airflow.sdk.execution_time.coordinator import BaseCoordinator
 
 log = structlog.getLogger(__name__)
 
@@ -151,7 +151,7 @@ class ProvidersManagerTaskRuntime(LoggingMixin):
         # Keeps dict of hooks keyed by connection type. They are lazy evaluated at access time
         self._hooks_lazy_dict: LazyDictWithCache[str, HookInfo | Callable] = LazyDictWithCache()
         self._plugins_set: set[PluginInfo] = set()
-        self._runtime_coordinators: list[type[BaseRuntimeCoordinator]] = []
+        self._coordinators: list[type[BaseCoordinator]] = []
         self._provider_schema_validator = _create_provider_info_schema_validator()
         self._init_airflow_core_hooks()
         # Populated by initialize_provider_configs(); holds provider-contributed config sections.
@@ -222,11 +222,11 @@ class ProvidersManagerTaskRuntime(LoggingMixin):
         self.initialize_providers_list()
         self._discover_taskflow_decorators()
 
-    @provider_info_cache("runtime_coordinators")
-    def initialize_providers_runtime_coordinators(self):
+    @provider_info_cache("coordinators")
+    def initialize_providers_coordinators(self):
         """Lazy initialization of providers runtime coordinators."""
         self.initialize_providers_list()
-        self._discover_runtime_coordinators()
+        self._discover_coordinators()
 
     @provider_info_cache("provider_configs")
     def initialize_provider_configs(self):
@@ -472,18 +472,18 @@ class ProvidersManagerTaskRuntime(LoggingMixin):
             connection_testable=hasattr(hook_class, "test_connection"),
         )
 
-    def _discover_runtime_coordinators(self) -> None:
-        """Retrieve and pre-load all runtime coordinators defined in the providers."""
+    def _discover_coordinators(self) -> None:
+        """Retrieve and pre-load all coordinators defined in the providers."""
         seen: set[str] = set()
         for provider_package, provider in self._provider_dict.items():
-            for coordinator_class_path in provider.data.get("runtime-coordinators", []):
+            for coordinator_class_path in provider.data.get("coordinators", []):
                 if coordinator_class_path in seen:
                     continue
                 coordinator_cls = _correctness_check(provider_package, coordinator_class_path, provider)
                 if coordinator_cls:
                     seen.add(coordinator_class_path)
-                    self._runtime_coordinators.append(coordinator_cls)
-        self._runtime_coordinators = sorted(self._runtime_coordinators, key=lambda c: c.__qualname__)
+                    self._coordinators.append(coordinator_cls)
+        self._coordinators = sorted(self._coordinators, key=lambda c: c.__qualname__)
 
     def _discover_filesystems(self) -> None:
         """Retrieve all filesystems defined in the providers."""
@@ -633,10 +633,10 @@ class ProvidersManagerTaskRuntime(LoggingMixin):
         return sorted(self._plugins_set, key=lambda x: x.plugin_class)
 
     @property
-    def runtime_coordinators(self) -> list[type[BaseRuntimeCoordinator]]:
+    def coordinators(self) -> list[type[BaseCoordinator]]:
         """Returns pre-loaded runtime coordinator classes available in providers."""
-        self.initialize_providers_runtime_coordinators()
-        return self._runtime_coordinators
+        self.initialize_providers_coordinators()
+        return self._coordinators
 
     @property
     def provider_configs(self) -> list[tuple[str, dict[str, Any]]]:
@@ -670,7 +670,7 @@ class ProvidersManagerTaskRuntime(LoggingMixin):
         self._asset_uri_handlers.clear()
         self._asset_factories.clear()
         self._asset_to_openlineage_converters.clear()
-        self._runtime_coordinators.clear()
+        self._coordinators.clear()
         self._provider_configs.clear()
 
         # Imported lazily to preserve SDK conf lazy initialization and avoid a configuration/runtime cycle.

--- a/task-sdk/tests/task_sdk/execution_time/test_coordinator.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_coordinator.py
@@ -25,7 +25,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from airflow.sdk.execution_time.coordinator import (
-    BaseRuntimeCoordinator,
+    BaseCoordinator,
     _bridge,
     _send_startup_details,
     _start_server,
@@ -156,17 +156,17 @@ class TestSendStartupDetails:
             server.close()
 
 
-class TestBaseRuntimeCoordinatorDefaults:
+class TestBaseCoordinatorDefaults:
     def test_can_handle_dag_file_returns_false(self):
-        assert BaseRuntimeCoordinator.can_handle_dag_file("bundle", "/path/to/dag.py") is False
+        assert BaseCoordinator.can_handle_dag_file("bundle", "/path/to/dag.py") is False
 
     def test_get_code_from_file_raises_not_implemented(self):
         with pytest.raises(NotImplementedError):
-            BaseRuntimeCoordinator.get_code_from_file("/path/to/dag.jar")
+            BaseCoordinator.get_code_from_file("/path/to/dag.jar")
 
-    def test_dag_parsing_runtime_cmd_raises_not_implemented(self):
+    def test_dag_parsing_cmd_raises_not_implemented(self):
         with pytest.raises(NotImplementedError):
-            BaseRuntimeCoordinator.dag_parsing_runtime_cmd(
+            BaseCoordinator.dag_parsing_cmd(
                 dag_file_path="/dag.jar",
                 bundle_name="b",
                 bundle_path="/path",
@@ -174,9 +174,9 @@ class TestBaseRuntimeCoordinatorDefaults:
                 logs_addr="127.0.0.1:1235",
             )
 
-    def test_task_execution_runtime_cmd_raises_not_implemented(self):
+    def test_task_execution_cmd_raises_not_implemented(self):
         with pytest.raises(NotImplementedError):
-            BaseRuntimeCoordinator.task_execution_runtime_cmd(
+            BaseCoordinator.task_execution_cmd(
                 what=MagicMock(),
                 dag_file_path="/dag.jar",
                 bundle_path="/path",
@@ -188,7 +188,7 @@ class TestBaseRuntimeCoordinatorDefaults:
 
 class TestCoordinatorNamedTuples:
     def test_dag_parsing_info_defaults(self):
-        info = BaseRuntimeCoordinator.DagParsingInfo(
+        info = BaseCoordinator.DagParsingInfo(
             dag_file_path="/dag.jar",
             bundle_name="my-bundle",
             bundle_path="/bundles/my-bundle",
@@ -202,7 +202,7 @@ class TestCoordinatorNamedTuples:
         mock_ti = MagicMock()
         mock_bundle = MagicMock()
         mock_startup = MagicMock()
-        info = BaseRuntimeCoordinator.TaskExecutionInfo(
+        info = BaseCoordinator.TaskExecutionInfo(
             what=mock_ti,
             dag_rel_path="dags/example.jar",
             bundle_info=mock_bundle,
@@ -319,9 +319,9 @@ class TestBridge:
 
 
 class TestRunDagParsing:
-    @patch.object(BaseRuntimeCoordinator, "_runtime_subprocess_entrypoint")
+    @patch.object(BaseCoordinator, "_runtime_subprocess_entrypoint")
     def test_run_dag_parsing_creates_dag_parsing_info(self, mock_entrypoint):
-        BaseRuntimeCoordinator.run_dag_parsing(
+        BaseCoordinator.run_dag_parsing(
             path="/bundles/my-bundle/dags/example.jar",
             bundle_name="my-bundle",
             bundle_path="/bundles/my-bundle",
@@ -329,7 +329,7 @@ class TestRunDagParsing:
 
         mock_entrypoint.assert_called_once()
         info = mock_entrypoint.call_args[0][0]
-        assert isinstance(info, BaseRuntimeCoordinator.DagParsingInfo)
+        assert isinstance(info, BaseCoordinator.DagParsingInfo)
         assert info.dag_file_path == "/bundles/my-bundle/dags/example.jar"
         assert info.bundle_name == "my-bundle"
         assert info.bundle_path == "/bundles/my-bundle"
@@ -337,13 +337,13 @@ class TestRunDagParsing:
 
 
 class TestRunTaskExecution:
-    @patch.object(BaseRuntimeCoordinator, "_runtime_subprocess_entrypoint")
+    @patch.object(BaseCoordinator, "_runtime_subprocess_entrypoint")
     def test_run_task_execution_creates_task_execution_info(self, mock_entrypoint):
         mock_ti = MagicMock()
         mock_bundle_info = MagicMock()
         mock_startup = MagicMock()
 
-        BaseRuntimeCoordinator.run_task_execution(
+        BaseCoordinator.run_task_execution(
             what=mock_ti,
             dag_rel_path="dags/example.jar",
             bundle_info=mock_bundle_info,
@@ -352,7 +352,7 @@ class TestRunTaskExecution:
 
         mock_entrypoint.assert_called_once()
         info = mock_entrypoint.call_args[0][0]
-        assert isinstance(info, BaseRuntimeCoordinator.TaskExecutionInfo)
+        assert isinstance(info, BaseCoordinator.TaskExecutionInfo)
         assert info.what is mock_ti
         assert info.dag_rel_path == "dags/example.jar"
         assert info.bundle_info is mock_bundle_info
@@ -362,8 +362,8 @@ class TestRunTaskExecution:
 
 class TestRuntimeSubprocessEntrypoint:
     def test_unknown_entrypoint_info_type_raises(self):
-        class TestCoordinator(BaseRuntimeCoordinator):
-            runtime_name = "test"
+        class TestCoordinator(BaseCoordinator):
+            sdk = "test"
             file_extension = ".test"
 
         # Needs a 'mode' attribute (accessed during logging) but must not be
@@ -402,15 +402,15 @@ class TestRuntimeSubprocessEntrypoint:
         # Mock supervisor_comm created from os.dup(0)
         supervisor_comm = MagicMock(spec=socket.socket)
 
-        class TestCoordinator(BaseRuntimeCoordinator):
-            runtime_name = "test"
+        class TestCoordinator(BaseCoordinator):
+            sdk = "test"
             file_extension = ".test"
 
             @classmethod
-            def dag_parsing_runtime_cmd(cls, **kwargs):
+            def dag_parsing_cmd(cls, **kwargs):
                 return ["test-runtime", "--parse", kwargs["dag_file_path"]]
 
-        info = BaseRuntimeCoordinator.DagParsingInfo(
+        info = BaseCoordinator.DagParsingInfo(
             dag_file_path="/dag.test",
             bundle_name="test-bundle",
             bundle_path="/bundles/test-bundle",
@@ -494,15 +494,15 @@ class TestRuntimeSubprocessEntrypoint:
         mock_bundle_info.version = "v1"
         mock_startup = MagicMock()
 
-        class TestCoordinator(BaseRuntimeCoordinator):
-            runtime_name = "test"
+        class TestCoordinator(BaseCoordinator):
+            sdk = "test"
             file_extension = ".test"
 
             @classmethod
-            def task_execution_runtime_cmd(cls, **kwargs):
+            def task_execution_cmd(cls, **kwargs):
                 return ["test-runtime", "--execute", kwargs["dag_file_path"]]
 
-        info = BaseRuntimeCoordinator.TaskExecutionInfo(
+        info = BaseCoordinator.TaskExecutionInfo(
             what=mock_ti,
             dag_rel_path="dags/example.test",
             bundle_info=mock_bundle_info,
@@ -555,15 +555,15 @@ class TestRuntimeSubprocessEntrypoint:
         read_stderr = MagicMock(spec=socket.socket)
         child_stderr.fileno.return_value = 10
 
-        class TestCoordinator(BaseRuntimeCoordinator):
-            runtime_name = "test"
+        class TestCoordinator(BaseCoordinator):
+            sdk = "test"
             file_extension = ".test"
 
             @classmethod
-            def dag_parsing_runtime_cmd(cls, **kwargs):
+            def dag_parsing_cmd(cls, **kwargs):
                 return ["echo", "test"]
 
-        info = BaseRuntimeCoordinator.DagParsingInfo(
+        info = BaseCoordinator.DagParsingInfo(
             dag_file_path="/dag.test",
             bundle_name="b",
             bundle_path="/path",

--- a/task-sdk/tests/task_sdk/test_providers_manager_runtime.py
+++ b/task-sdk/tests/task_sdk/test_providers_manager_runtime.py
@@ -244,7 +244,7 @@ class TestProvidersManagerRuntime:
             pm.already_initialized_provider_configs
 
     @patch("airflow.sdk.providers_manager_runtime.import_string")
-    def test_runtime_coordinators(self, mock_import_string):
+    def test_coordinators(self, mock_import_string):
         class ACoordinator:
             pass
 
@@ -259,7 +259,7 @@ class TestProvidersManagerRuntime:
         providers_manager._provider_dict["apache-airflow-providers-sdk-java"] = ProviderInfo(
             version="0.0.1",
             data={
-                "runtime-coordinators": [
+                "coordinators": [
                     "airflow.providers.sdk.java.coordinator.ZCoordinator",
                     "airflow.providers.sdk.java.coordinator.ACoordinator",
                     "airflow.providers.sdk.java.coordinator.ZCoordinator",
@@ -268,7 +268,7 @@ class TestProvidersManagerRuntime:
         )
 
         with patch.object(providers_manager, "initialize_providers_list"):
-            assert providers_manager.runtime_coordinators == [ACoordinator, ZCoordinator]
+            assert providers_manager.coordinators == [ACoordinator, ZCoordinator]
 
     def test_initialize_provider_configs_can_reload_sdk_conf(self):
         from airflow.sdk.configuration import conf


### PR DESCRIPTION
Tweak coordinator class names, attribute names, and method names to be shorter and avoid the term 'runtime'.