### PR TITLE
Remove dag parameters for now

### DIFF
--- a/java-sdk/example/src/java/org/apache/airflow/example/JavaExampleBuilder.java
+++ b/java-sdk/example/src/java/org/apache/airflow/example/JavaExampleBuilder.java
@@ -70,7 +70,7 @@ public class JavaExampleBuilder {
   }
 
   public static Dag build() {
-    var dag = new Dag("java_example", /* description= */ null, /* schedule= */ "@daily");
+    var dag = new Dag("java_example");
     dag.addTask("extract", Extract.class, List.of());
     dag.addTask("transform", Transform.class, List.of("extract"));
     dag.addTask("load", Load.class, List.of("transform"));

--- a/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/Bundle.kt
+++ b/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/Bundle.kt
@@ -29,8 +29,8 @@ class Bundle(
 private fun Iterable<Dag>.associateByDagId(): Map<String, Dag> {
   val dagMap = linkedMapOf<String, Dag>()
   for (dag in this) {
-    require(dagMap.putIfAbsent(dag.dagId, dag) == null) {
-      "Duplicate dagId in bundle: ${dag.dagId}"
+    require(dagMap.putIfAbsent(dag.id, dag) == null) {
+      "Dags in bundle have duplicate ID: ${dag.id}"
     }
   }
   return dagMap

--- a/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/BundleInspector.kt
+++ b/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/BundleInspector.kt
@@ -49,10 +49,10 @@ object BundleInspector {
     buildString {
       appendLine("dags:")
       for (dag in dags) {
-        appendLine("  ${dag.dagId}:")
+        appendLine("  ${dag.id}:")
         appendLine("    tasks:")
-        for (taskId in dag.tasks.keys) {
-          appendLine("      - $taskId")
+        for (id in dag.tasks.keys) {
+          appendLine("      - $id")
         }
       }
     }

--- a/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/Dag.kt
+++ b/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/Dag.kt
@@ -19,87 +19,29 @@
 
 package org.apache.airflow.sdk
 
-import java.time.Duration
-import java.time.Instant
-
 /**
- * A Dag (Directed Acyclic Graph) is a collection of tasks with directional dependencies.
+ * Collection of tasks with directional dependencies.
  *
- * A Dag has a schedule, a start date and an end date (optional). For each schedule
- * (say daily or hourly), the Dag needs to run each individual task as their
- * dependencies are met.
- *
- * @param dagId The id of the Dag; must consist exclusively of alphanumeric characters,
+ * @param id The Dag's id. This must consist exclusively of alphanumeric characters,
  *   dashes, dots and underscores (all ASCII).
- * @param description The description for the Dag to e.g. be shown on the webserver.
- * @param schedule Defines when Dag runs are scheduled. Can be a cron expression string
- *   (e.g. "0 0 * * *"), a preset (e.g. "@daily", "@hourly", "@once", "@continuous"),
- *   or null for no schedule.
- * @param startDate The timestamp from which the scheduler will attempt to backfill.
- * @param endDate A date beyond which your Dag won't run; leave null for open-ended scheduling.
- * @param defaultArgs A map of default parameters to be used as constructor keyword
- *   parameters when initialising operators.
- * @param maxActiveTasks The number of task instances allowed to run concurrently per Dag run.
- * @param maxActiveRuns Maximum number of active Dag runs.
- * @param maxConsecutiveFailedDagRuns Maximum number of consecutive failed Dag runs,
- *   beyond this the scheduler will disable the Dag.
- * @param dagrunTimeout Duration a DagRun is allowed to run before it times out or fails.
- * @param catchup Perform scheduler catchup (or only run latest)? Defaults to false.
- * @param docMd Documentation in markdown format.
- * @param accessControl Optional Dag-level access control actions, e.g.
- *   mapOf("role1" to mapOf("DAGs" to setOf("can_read", "can_edit"))).
- * @param isPausedUponCreation Whether the Dag is paused when created for the first time.
- * @param tags Set of tags to help filtering Dags in the UI.
- * @param ownerLinks Map of owners and their links, clickable on the Dags view UI.
- * @param failFast Fails currently running tasks when a task in Dag fails.
- * @param dagDisplayName The display name of the Dag on the UI. Defaults to dagId.
- * @param renderTemplateAsNativeObj If true, uses native rendering for templates.
- * @param params A map of Dag-level parameters accessible in templates, namespaced under
- *   "params". These can be overridden at the task level.
  */
-class Dag
+class Dag(
+  // TODO: charset check?
+  val id: String,
+) {
+  internal var tasks = mutableMapOf<String, Class<out Task>>()
+  internal var dependants = mutableMapOf<String, MutableSet<String>>()
+
   @JvmOverloads
-  constructor(
-    val dagId: String,
-    val description: String? = null,
-    val schedule: String? = null,
-    val startDate: Instant? = null,
-    val endDate: Instant? = null,
-    val defaultArgs: Map<String, Any> = emptyMap(),
-    val maxActiveTasks: Int = DEFAULT_MAX_ACTIVE_TASKS,
-    val maxActiveRuns: Int = DEFAULT_MAX_ACTIVE_RUNS,
-    val maxConsecutiveFailedDagRuns: Int = DEFAULT_MAX_CONSECUTIVE_FAILED_DAG_RUNS,
-    val dagrunTimeout: Duration? = null,
-    val catchup: Boolean = false,
-    val docMd: String? = null,
-    val accessControl: Map<String, Map<String, Set<String>>>? = null,
-    val isPausedUponCreation: Boolean? = null,
-    val tags: Set<String> = emptySet(),
-    val ownerLinks: Map<String, String> = emptyMap(),
-    val failFast: Boolean = false,
-    val dagDisplayName: String? = null,
-    val renderTemplateAsNativeObj: Boolean = false,
-    val params: Map<String, Any>? = null,
+  fun addTask(
+    id: String,
+    definition: Class<out Task>,
+    dependsOn: List<String> = emptyList(),
   ) {
-    internal var tasks = mutableMapOf<String, Class<out Task>>()
-    internal var dependants = mutableMapOf<String, MutableSet<String>>()
-
-    @JvmOverloads
-    fun addTask(
-      id: String,
-      definition: Class<out Task>,
-      dependsOn: List<String> = emptyList(),
-    ) {
-      // TODO: Check duplicate key.
-      tasks[id] = definition
-      for (parent in dependsOn) {
-        dependants.getOrPut(parent) { mutableSetOf() }.add(id)
-      }
-    }
-
-    companion object {
-      const val DEFAULT_MAX_ACTIVE_TASKS = 16
-      const val DEFAULT_MAX_ACTIVE_RUNS = 16
-      const val DEFAULT_MAX_CONSECUTIVE_FAILED_DAG_RUNS = 0
+    // TODO: Check duplicate key.
+    tasks[id] = definition
+    for (parent in dependsOn) {
+      dependants.getOrPut(parent) { mutableSetOf() }.add(id)
     }
   }
+}

--- a/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/execution/Serde.kt
+++ b/java-sdk/sdk/src/main/kotlin/org/apache/airflow/sdk/execution/Serde.kt
@@ -45,10 +45,10 @@ private val logger = Logger(SerdeScope::class)
  *
  * Primitives pass through; complex types are wrapped in {"__type": ..., "__var": ...}.
  * This matches the Python BaseSerialization.serialize() output exactly:
- * - dict  -> {"__type": "dict",      "__var": {k: serialize(v), ...}}
- * - set   -> {"__type": "set",       "__var": [sorted items]}
- * - datetime -> {"__type": "datetime",  "__var": epoch_seconds}
- * - timedelta -> {"__type": "timedelta", "__var": total_seconds}
+ * - Map -> {"__type": "dict", "__var": {k: serialize(v), ...}}
+ * - Set -> {"__type": "set", "__var": [sorted items]}
+ * - Datetime -> {"__type": "datetime", "__var": epoch_seconds}
+ * - Timedelta -> {"__type": "timedelta", "__var": total_seconds}
  */
 internal fun serializeValue(value: Any?): Any? =
   when (value) {
@@ -85,54 +85,15 @@ internal fun serializeValue(value: Any?): Any? =
     else -> value.toString()
   }
 
-/**
- * Unwrap a single level of type encoding, extracting the "__var" part.
- *
- * In Python's serialize_to_json, non-decorated fields are serialized then unwrapped:
- *   value = cls.serialize(value)
- *   if isinstance(value, dict) and Encoding.TYPE in value:
- *       value = value[Encoding.VAR]
- */
-private fun unwrapTypeEncoding(value: Any?): Any? =
-  if (value is Map<*, *> && "__type" in value && "__var" in value) {
-    value["__var"]
-  } else {
-    value
-  }
-
 // ---------------------------------------------------------------------------
 // Timetable serialization
 // ---------------------------------------------------------------------------
 
-private fun serializeTimetable(schedule: String?): Serialized =
-  when (schedule) {
-    null ->
-      mapOf(
-        "__type" to "airflow.timetables.simple.NullTimetable",
-        "__var" to emptyMap<String, Any>(),
-      )
-    "@once" ->
-      mapOf(
-        "__type" to "airflow.timetables.simple.OnceTimetable",
-        "__var" to emptyMap<String, Any>(),
-      )
-    "@continuous" ->
-      mapOf(
-        "__type" to "airflow.timetables.simple.ContinuousTimetable",
-        "__var" to emptyMap<String, Any>(),
-      )
-    else ->
-      mapOf(
-        "__type" to "airflow.timetables.trigger.CronTriggerTimetable",
-        "__var" to
-          mapOf(
-            "expression" to schedule,
-            "timezone" to "UTC",
-            "interval" to 0.0,
-            "run_immediately" to false,
-          ),
-      )
-  }
+private fun serializeTimetable(): Serialized =
+  mapOf(
+    "__type" to "airflow.timetables.simple.NullTimetable",
+    "__var" to emptyMap<String, Any>(),
+  )
 
 // ---------------------------------------------------------------------------
 // Task serialization
@@ -200,67 +161,26 @@ private fun Dag.serialize(
   id: String,
   fileloc: String,
   relativeFileloc: String,
-): Serialized {
-  val result =
-    mutableMapOf<String, Any?>(
-      // Required fields (always present)
-      "dag_id" to id,
-      "fileloc" to fileloc,
-      "relative_fileloc" to relativeFileloc,
-      // Always serialized
-      "timezone" to "UTC",
-      "timetable" to serializeTimetable(schedule),
-      "tasks" to tasks.entries.map { (taskId, task) -> task.serialize(taskId, dependants[taskId]) },
-      "dag_dependencies" to emptyList<Any>(),
-      "task_group" to serializeTaskGroup(tasks.keys),
-      "edge_info" to emptyMap<String, Any>(),
-      "params" to (params?.let { serializeParams(it) } ?: emptyList<Any>()),
-      "deadline" to null,
-      "allowed_run_types" to null,
-    )
-
-  // Optional fields — only include if non-null.
-  // Non-decorated fields are serialized then unwrapped (matching Python's serialize_to_json).
-  description?.let { result["description"] = it }
-  startDate?.let { result["start_date"] = unwrapTypeEncoding(serializeValue(it)) }
-  endDate?.let { result["end_date"] = unwrapTypeEncoding(serializeValue(it)) }
-  dagrunTimeout?.let { result["dagrun_timeout"] = unwrapTypeEncoding(serializeValue(it)) }
-  docMd?.let { result["doc_md"] = it }
-  isPausedUponCreation?.let { result["is_paused_upon_creation"] = it }
-
-  // Decorated fields (kept with __type/__var encoding, NOT unwrapped)
-  if (defaultArgs.isNotEmpty()) {
-    result["default_args"] = serializeValue(defaultArgs)
-  }
-  if (accessControl != null) {
-    // access_control is always serialized when not null, even if empty
-    result["access_control"] = serializeValue(accessControl)
-  }
-
-  // Fields excluded when matching schema defaults
-  if (catchup) result["catchup"] = true
-  if (failFast) result["fail_fast"] = true
-  if (maxActiveTasks != Dag.DEFAULT_MAX_ACTIVE_TASKS) result["max_active_tasks"] = maxActiveTasks
-  if (maxActiveRuns != Dag.DEFAULT_MAX_ACTIVE_RUNS) result["max_active_runs"] = maxActiveRuns
-  if (maxConsecutiveFailedDagRuns != Dag.DEFAULT_MAX_CONSECUTIVE_FAILED_DAG_RUNS) {
-    result["max_consecutive_failed_dag_runs"] = maxConsecutiveFailedDagRuns
-  }
-  if (renderTemplateAsNativeObj) result["render_template_as_native_obj"] = true
-
-  // dag_display_name — excluded when it equals dag_id (the default)
-  if (dagDisplayName != null && dagDisplayName != id) {
-    result["dag_display_name"] = dagDisplayName
-  }
-
-  // Collection fields — serialized then unwrapped; excluded when empty
-  if (tags.isNotEmpty()) result["tags"] = unwrapTypeEncoding(serializeValue(tags))
-  if (ownerLinks.isNotEmpty()) result["owner_links"] = unwrapTypeEncoding(serializeValue(ownerLinks))
-
-  return result
-}
+): Serialized =
+  mutableMapOf(
+    // Required fields (always present)
+    "dag_id" to id,
+    "fileloc" to fileloc,
+    "relative_fileloc" to relativeFileloc,
+    // Always serialized
+    "timezone" to "UTC",
+    "timetable" to serializeTimetable(),
+    "tasks" to tasks.entries.map { (taskId, task) -> task.serialize(taskId, dependants[taskId]) },
+    "dag_dependencies" to emptyList<Any>(),
+    "task_group" to serializeTaskGroup(tasks.keys),
+    "edge_info" to emptyMap<String, Any>(),
+    "params" to serializeParams(emptyMap()),
+    "deadline" to null,
+    "allowed_run_types" to null,
+  )
 
 /** Serialize a single DAG to a dict. Exposed for cross-language validation testing. */
-internal fun serializeDag(dag: Dag): Serialized = dag.serialize(dag.dagId, "", "")
+internal fun serializeDag(dag: Dag): Serialized = dag.serialize(dag.id, "", "")
 
 // ---------------------------------------------------------------------------
 // Top-level envelope — matches Python's DagSerialization.to_dict

--- a/java-sdk/sdk/src/test/kotlin/org/apache/airflow/sdk/BundleTest.kt
+++ b/java-sdk/sdk/src/test/kotlin/org/apache/airflow/sdk/BundleTest.kt
@@ -42,6 +42,6 @@ internal class BundleTest {
         Bundle("0", listOf(Dag("dag"), Dag("dag")))
       }
 
-    Assertions.assertEquals("Duplicate dagId in bundle: dag", error.message)
+    Assertions.assertEquals("Dags in bundle have duplicate ID: dag", error.message)
   }
 }

--- a/java-sdk/sdk/src/test/kotlin/org/apache/airflow/sdk/execution/SerializationCompatibilityTest.kt
+++ b/java-sdk/sdk/src/test/kotlin/org/apache/airflow/sdk/execution/SerializationCompatibilityTest.kt
@@ -28,15 +28,13 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.TestFactory
 import java.io.File
-import java.time.Duration
-import java.time.Instant
 
 /**
- * Reads test_dags.yaml, constructs Dags from the parameters, serialises each
+ * Reads test_dags.yaml, constructs Dags from the parameters, serializes each
  * one with the Java SDK, and writes the result to serialized_java.json for
  * cross-language comparison with the Python output.
  *
- * Each YAML test-case is turned into a JUnit 5 dynamic test so failures are
+ * Each YAML test-case is turned into a JUnit 5 dynamic test, so failures are
  * reported individually.
  *
  * After running:
@@ -72,43 +70,7 @@ class SerializationCompatibilityTest {
   // -----------------------------------------------------------------------
 
   @Suppress("UNCHECKED_CAST")
-  private fun constructDag(params: Map<String, Any?>): Dag {
-    val dagId = params["dag_id"] as String
-
-    return Dag(
-      dagId = dagId,
-      description = params["description"] as? String,
-      schedule = params["schedule"] as? String,
-      startDate = (params["start_date"] as? String)?.let { Instant.parse(it) },
-      endDate = (params["end_date"] as? String)?.let { Instant.parse(it) },
-      defaultArgs = (params["default_args"] as? Map<String, Any>) ?: emptyMap(),
-      maxActiveTasks = (params["max_active_tasks"] as? Number)?.toInt() ?: Dag.DEFAULT_MAX_ACTIVE_TASKS,
-      maxActiveRuns = (params["max_active_runs"] as? Number)?.toInt() ?: Dag.DEFAULT_MAX_ACTIVE_RUNS,
-      maxConsecutiveFailedDagRuns =
-        (params["max_consecutive_failed_dag_runs"] as? Number)?.toInt()
-          ?: Dag.DEFAULT_MAX_CONSECUTIVE_FAILED_DAG_RUNS,
-      dagrunTimeout = (params["dagrun_timeout_seconds"] as? Number)?.let { Duration.ofSeconds(it.toLong()) },
-      catchup = params["catchup"] as? Boolean ?: false,
-      docMd = params["doc_md"] as? String,
-      accessControl =
-        (params["access_control"] as? Map<String, Map<String, Any>>)?.mapValues { (_, resources) ->
-          resources.mapValues { (_, perms) ->
-            when (perms) {
-              is List<*> -> perms.filterIsInstance<String>().toSet()
-              is Set<*> -> perms.filterIsInstance<String>().toSet()
-              else -> setOf(perms.toString())
-            }
-          }
-        },
-      isPausedUponCreation = params["is_paused_upon_creation"] as? Boolean,
-      tags = (params["tags"] as? List<*>)?.filterIsInstance<String>()?.toSet() ?: emptySet(),
-      ownerLinks = (params["owner_links"] as? Map<String, String>) ?: emptyMap(),
-      failFast = params["fail_fast"] as? Boolean ?: false,
-      dagDisplayName = params["dag_display_name"] as? String,
-      renderTemplateAsNativeObj = params["render_template_as_native_obj"] as? Boolean ?: false,
-      params = params["params"] as? Map<String, Any>,
-    )
-  }
+  private fun constructDag(params: Map<String, Any?>): Dag = Dag(params["dag_id"] as String)
 
   // -----------------------------------------------------------------------
   // Dynamic test generation


### PR DESCRIPTION
Since we're not (explicitly) supporting pure Java Dags for the moment, these params are not useful. Removing them makes it easier to implement the annotation-based authoring interface.

We will revert this commit when we come back to finish pure Java Dag support.