### PR TITLE
Decouple coordinator base from subprocess transport

### DIFF
--- a/sdk/coordinators/java/src/airflow/sdk/coordinators/java/coordinator.py
+++ b/sdk/coordinators/java/src/airflow/sdk/coordinators/java/coordinator.py
@@ -26,14 +26,14 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from airflow.sdk.coordinators.java.bundle_scanner import BundleScanner, read_dag_code
-from airflow.sdk.execution_time.coordinator import BaseCoordinator
+from airflow.sdk.execution_time.coordinator import SubprocessCoordinator
 
 if TYPE_CHECKING:
     from airflow.sdk.api.datamodels._generated import BundleInfo
     from airflow.sdk.execution_time.workloads.task import TaskInstanceDTO
 
 
-class JavaCoordinator(BaseCoordinator):
+class JavaCoordinator(SubprocessCoordinator):
     """
     Coordinator that launches a JVM subprocess for DAG parsing and task execution.
 

--- a/task-sdk/src/airflow/sdk/execution_time/coordinator.py
+++ b/task-sdk/src/airflow/sdk/execution_time/coordinator.py
@@ -16,29 +16,12 @@
 # specific language governing permissions and limitations
 # under the License.
 """
-Runtime coordinator for non-Python DAG file processing and task execution.
+Runtime coordinator interfaces for non-Python Dag file processing and task execution.
 
-Provides :class:`BaseCoordinator`, the base class for
-SDK-specific coordinators that bridge subprocess I/O between the
-Airflow supervisor and an external-SDK runtime (Java, Go, Rust, etc.),
-and :class:`CoordinatorManager`, the registry that loads coordinator
-instances from the ``[sdk] coordinators`` configuration.
-
-The coordinator's :meth:`~BaseCoordinator.run_dag_parsing` and
-:meth:`~BaseCoordinator.run_task_execution` methods handle the full lifecycle:
-
-1. Creates TCP servers for comm and logs channels, and a socketpair for stderr.
-2. Calls :meth:`~BaseCoordinator.dag_parsing_cmd` or
-   :meth:`~BaseCoordinator.task_execution_cmd` (provided by the subclass) to
-   obtain the subprocess command.
-3. Spawns the subprocess and accepts TCP connections from it.
-4. Runs a selector-based bridge that transparently forwards bytes
-   between fd 0 (supervisor) and the subprocess comm socket, and
-   re-emits the subprocess's log and stderr output through structlog.
-
-I/O multiplexing uses the same selector-based loop as
-:class:`~airflow.sdk.execution_time.supervisor.WatchedSubprocess`,
-driven by :func:`~airflow.sdk.execution_time.selector_loop.service_selector`.
+Provides :class:`BaseCoordinator`, the transport-neutral base class for
+SDK-specific coordinators, :class:`SubprocessCoordinator`, the reusable
+subprocess/socket implementation, and :class:`CoordinatorManager`, the registry
+that loads coordinator instances from the ``[sdk] coordinators`` configuration.
 """
 
 from __future__ import annotations
@@ -182,11 +165,10 @@ class BaseCoordinator:
     via :func:`~airflow.sdk._shared.module_loading.import_string` and
     constructed with the entry's ``kwargs``.
 
-    Subclasses represent a specific SDK runtime (Java, Go, etc.) and only
-    need to implement :meth:`can_handle_dag_file`, :meth:`dag_parsing_cmd`
-    and :meth:`task_execution_cmd`.  The base class owns the entire bridge
-    lifecycle: TCP servers, subprocess management, selector-based I/O loop,
-    and cleanup.
+    Subclasses represent a specific SDK runtime (Java, Go, etc.).  The base
+    class exposes only high-level operations such as Dag parsing and task
+    execution; concrete coordinators choose their own process model and
+    communication transport.
     """
 
     sdk: ClassVar[str]
@@ -237,6 +219,25 @@ class BaseCoordinator:
         """
         raise NotImplementedError
 
+    def run_dag_parsing(self, *, path: str, bundle_name: str, bundle_path: str) -> None:
+        """Entry point for running runtime-specific Dag File Processing."""
+        raise NotImplementedError
+
+    def run_task_execution(
+        self,
+        *,
+        what: TaskInstanceDTO,
+        dag_rel_path: str | os.PathLike[str],
+        bundle_info: BundleInfo,
+        startup_details: StartupDetails,
+    ) -> None:
+        """Entry point for running runtime-specific task execution."""
+        raise NotImplementedError
+
+
+class SubprocessCoordinator(BaseCoordinator):
+    """Coordinator base class for runtimes launched as socket-connected subprocesses."""
+
     def dag_parsing_cmd(
         self,
         *,
@@ -247,11 +248,11 @@ class BaseCoordinator:
         logs_addr: str,
     ) -> list[str]:
         """
-        Return the subprocess command for DAG file parsing.
+        Return the subprocess command for Dag file parsing.
 
-        :param dag_file_path: Absolute path to the DAG file to parse.
-        :param bundle_name: Name of the DAG bundle.
-        :param bundle_path: Root path of the DAG bundle.
+        :param dag_file_path: Absolute path to the Dag file to parse.
+        :param bundle_name: Name of the Dag bundle.
+        :param bundle_path: Root path of the Dag bundle.
         :param comm_addr: ``host:port`` the subprocess must connect to
             for the bidirectional msgpack comm channel.
         :param logs_addr: ``host:port`` the subprocess must connect to
@@ -274,8 +275,8 @@ class BaseCoordinator:
         Return the subprocess command for task execution.
 
         :param what: The task instance to execute.
-        :param dag_file_path: Absolute path to the DAG file.
-        :param bundle_path: Root path of the DAG bundle.
+        :param dag_file_path: Absolute path to the Dag file.
+        :param bundle_path: Root path of the Dag bundle.
         :param bundle_info: Bundle metadata.
         :param comm_addr: ``host:port`` the subprocess must connect to
             for the bidirectional msgpack comm channel.
@@ -286,7 +287,7 @@ class BaseCoordinator:
         raise NotImplementedError
 
     def run_dag_parsing(self, *, path: str, bundle_name: str, bundle_path: str) -> None:
-        """Entry point for running runtime-specific Dag File Processing."""
+        """Run Dag File Processing in a socket-connected subprocess."""
         self._runtime_subprocess_entrypoint(
             self.DagParsingInfo(
                 dag_file_path=path,
@@ -303,6 +304,7 @@ class BaseCoordinator:
         bundle_info: BundleInfo,
         startup_details: StartupDetails,
     ) -> None:
+        """Run task execution in a socket-connected subprocess."""
         self._runtime_subprocess_entrypoint(
             self.TaskExecutionInfo(
                 what=what,
@@ -312,7 +314,9 @@ class BaseCoordinator:
             )
         )
 
-    def _runtime_subprocess_entrypoint(self, entrypoint_info: DagParsingInfo | TaskExecutionInfo) -> None:
+    def _runtime_subprocess_entrypoint(
+        self, entrypoint_info: BaseCoordinator.DagParsingInfo | BaseCoordinator.TaskExecutionInfo
+    ) -> None:
         """
         Spawn the runtime subprocess and bridge I/O with the supervisor.
 
@@ -546,6 +550,7 @@ def reset_coordinator_manager() -> None:
 
 __all__ = [
     "BaseCoordinator",
+    "SubprocessCoordinator",
     "CoordinatorManager",
     "get_coordinator_manager",
     "reset_coordinator_manager",

--- a/task-sdk/tests/task_sdk/execution_time/test_coordinator.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_coordinator.py
@@ -30,6 +30,7 @@ import pytest
 from airflow.sdk.execution_time.coordinator import (
     BaseCoordinator,
     CoordinatorManager,
+    SubprocessCoordinator,
     _bridge,
     _send_startup_details,
     _start_server,
@@ -92,7 +93,7 @@ class TestSendStartupDetails:
         assert length == len(sent_bytes) - 4
 
     def test_frame_contains_response_id_zero(self):
-        import msgpack
+        from msgspec import msgpack
 
         mock_startup = MagicMock()
         mock_startup.model_dump.return_value = {"type": "StartupDetails"}
@@ -102,11 +103,11 @@ class TestSendStartupDetails:
         _send_startup_details(mock_socket, mock_startup)
 
         sent_bytes = mock_socket.sendall.call_args[0][0]
-        frame = msgpack.unpackb(sent_bytes[4:])
+        frame = msgpack.decode(sent_bytes[4:])
         assert frame[0] == 0
 
     def test_frame_body_matches_model_dump(self):
-        import msgpack
+        from msgspec import msgpack
 
         body = {"type": "StartupDetails", "ti": {"task_id": "t1"}, "dag_rel_path": "test.jar"}
         mock_startup = MagicMock()
@@ -117,11 +118,11 @@ class TestSendStartupDetails:
         _send_startup_details(mock_socket, mock_startup)
 
         sent_bytes = mock_socket.sendall.call_args[0][0]
-        frame = msgpack.unpackb(sent_bytes[4:])
+        frame = msgpack.decode(sent_bytes[4:])
         assert frame[1] == body
 
     def test_real_socket_roundtrip(self):
-        import msgpack
+        from msgspec import msgpack
 
         server = socket.socket()
         server.bind(("127.0.0.1", 0))
@@ -143,7 +144,7 @@ class TestSendStartupDetails:
             length = int.from_bytes(length_bytes, "big")
 
             data = client.recv(length)
-            frame = msgpack.unpackb(data)
+            frame = msgpack.decode(data)
             assert frame[0] == 0
             assert frame[1] == body
         finally:
@@ -160,9 +161,29 @@ class TestBaseCoordinatorDefaults:
         with pytest.raises(NotImplementedError):
             BaseCoordinator().get_code_from_file("/path/to/dag.jar")
 
+    def test_base_coordinator_does_not_expose_subprocess_transport_hooks(self):
+        assert not hasattr(BaseCoordinator, "dag_parsing_cmd")
+        assert not hasattr(BaseCoordinator, "task_execution_cmd")
+        assert not hasattr(BaseCoordinator, "_runtime_subprocess_entrypoint")
+
+    def test_run_dag_parsing_raises_not_implemented(self):
+        with pytest.raises(NotImplementedError):
+            BaseCoordinator().run_dag_parsing(path="/dag.jar", bundle_name="b", bundle_path="/path")
+
+    def test_run_task_execution_raises_not_implemented(self):
+        with pytest.raises(NotImplementedError):
+            BaseCoordinator().run_task_execution(
+                what=MagicMock(),
+                dag_rel_path="/dag.jar",
+                bundle_info=MagicMock(),
+                startup_details=MagicMock(),
+            )
+
+
+class TestSubprocessCoordinatorDefaults:
     def test_dag_parsing_cmd_raises_not_implemented(self):
         with pytest.raises(NotImplementedError):
-            BaseCoordinator().dag_parsing_cmd(
+            SubprocessCoordinator().dag_parsing_cmd(
                 dag_file_path="/dag.jar",
                 bundle_name="b",
                 bundle_path="/path",
@@ -172,7 +193,7 @@ class TestBaseCoordinatorDefaults:
 
     def test_task_execution_cmd_raises_not_implemented(self):
         with pytest.raises(NotImplementedError):
-            BaseCoordinator().task_execution_cmd(
+            SubprocessCoordinator().task_execution_cmd(
                 what=MagicMock(),
                 dag_file_path="/dag.jar",
                 bundle_path="/path",
@@ -296,7 +317,7 @@ class TestBridge:
         mock_sel.close.assert_called_once()
 
 
-class _StubCoordinator(BaseCoordinator):
+class _StubCoordinator(SubprocessCoordinator):
     sdk = "test"
     file_extension = ".test"
 
@@ -312,7 +333,7 @@ class _StubCoordinator(BaseCoordinator):
 
 
 class TestRunDagParsing:
-    @patch.object(BaseCoordinator, "_runtime_subprocess_entrypoint")
+    @patch.object(SubprocessCoordinator, "_runtime_subprocess_entrypoint")
     def test_run_dag_parsing_creates_dag_parsing_info(self, mock_entrypoint):
         coordinator = _StubCoordinator()
         coordinator.run_dag_parsing(
@@ -331,7 +352,7 @@ class TestRunDagParsing:
 
 
 class TestRunTaskExecution:
-    @patch.object(BaseCoordinator, "_runtime_subprocess_entrypoint")
+    @patch.object(SubprocessCoordinator, "_runtime_subprocess_entrypoint")
     def test_run_task_execution_creates_task_execution_info(self, mock_entrypoint):
         mock_ti = MagicMock()
         mock_bundle_info = MagicMock()


### PR DESCRIPTION
## Summary

- Split the transport-neutral coordinator contract into `BaseCoordinator` high-level operations.
- Move the reusable subprocess/socket implementation into `SubprocessCoordinator`.
- Keep `JavaCoordinator` behavior unchanged by making it subclass `SubprocessCoordinator`.

Addresses apache/airflow#66838.

## Test Plan

- `uv run ruff check task-sdk/src/airflow/sdk/execution_time/coordinator.py task-sdk/tests/task_sdk/execution_time/test_coordinator.py sdk/coordinators/java/src/airflow/sdk/coordinators/java/coordinator.py sdk/coordinators/java/tests/unit/coordinators/java/test_coordinator.py`
- `uv run --project task-sdk pytest task-sdk/tests/task_sdk/execution_time/test_coordinator.py -q`
- `uv run --project sdk/coordinators/java pytest sdk/coordinators/java/tests/unit/coordinators/java/test_coordinator.py -q`
- `git diff --check`
