### PR TITLE
Accept `[sdk] coordinators` as dict and support lazy initialization 

### DIFF
--- a/airflow-core/src/airflow/config_templates/config.yml
+++ b/airflow-core/src/airflow/config_templates/config.yml
@@ -1972,35 +1972,35 @@ sdk:
   options:
     coordinators:
       description: |
-        JSON list of runtime coordinator entries.
+        JSON object mapping of coordinator keys to coordinator definitions.
 
-        Each entry is an object with ``name``, ``classpath`` and optional
-        ``kwargs``.  ``classpath`` is resolved via ``import_string`` and
-        constructed with ``kwargs`` once per process.  Entries are
+        Each value is an object with ``classpath`` and optional ``kwargs``.
+        ``classpath`` is resolved via ``import_string`` and constructed with
+        ``kwargs`` on first use.  Entries are
         independent instances, so the same ``classpath`` can be configured
-        multiple times with different ``kwargs`` (for example, two
-        ``JavaCoordinator`` instances pinned to different JDK versions).
-      version_added: 3.1.7
+        multiple times under different names with different ``kwargs`` (for
+        example, two ``JavaCoordinator`` instances pinned to different JDK
+        versions).
+      version_added: 3.3.0
       type: string
       example: |
-        [
-          {
-            "name": "jdk-17",
+        {
+          "jdk-17": {
             "classpath": "airflow.sdk.coordinators.java.JavaCoordinator",
             "kwargs": {"java_executable": "/usr/lib/jvm/java-17-openjdk/bin/java", "jvm_args": ["-Xmx1024m"]}
           }
-        ]
+        }
       default: ~
     queue_to_coordinator:
       description: |
-        JSON mapping of queue names to coordinator ``name`` from
+        JSON mapping of queue names to a coordinator key from
         ``[sdk] coordinators``.
 
         When a task's ``language`` field is not set, this mapping is checked
         to route the task to a configured coordinator instance based on its
         queue.  This is useful when queues are used as environment or
         isolation identifiers (e.g. ``legacy-java``, ``modern-java``).
-      version_added: 3.1.7
+      version_added: 3.3.0
       type: string
       example: '{"legacy-java": "jdk-11", "modern-java": "jdk-17"}'
       default: ~

--- a/task-sdk/src/airflow/sdk/execution_time/coordinator.py
+++ b/task-sdk/src/airflow/sdk/execution_time/coordinator.py
@@ -42,12 +42,15 @@ driven by :func:`~airflow.sdk.execution_time.selector_loop.service_selector`.
 
 from __future__ import annotations
 
+import contextlib
 import functools
 from typing import TYPE_CHECKING, Any
 
 import attrs
+import pydantic
 
 from airflow.sdk._shared.module_loading import import_string
+from airflow.sdk.configuration import conf
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -58,6 +61,13 @@ if TYPE_CHECKING:
 
     from airflow.sdk.api.client import Client
     from airflow.sdk.execution_time.workloads.task import TaskInstanceDTO
+
+__all__ = [
+    "BaseCoordinator",
+    "CoordinatorManager",
+    "get_coordinator_manager",
+    "reset_coordinator_manager",
+]
 
 
 class BaseCoordinator:
@@ -95,6 +105,11 @@ class BaseCoordinator:
         This should execute the task and return a result.
         """
         raise NotImplementedError
+
+
+class _CoordinatorSpec(pydantic.BaseModel):
+    classpath: str
+    kwargs: dict[str, Any]
 
 
 class _PythonCoordinator(BaseCoordinator):
@@ -138,60 +153,60 @@ def _build_python_coordinator() -> _PythonCoordinator:
     return _PythonCoordinator()
 
 
-@attrs.define
+@attrs.define(kw_only=True)
 class CoordinatorManager:
     """
-    Registry of coordinator instances loaded from the ``[sdk] coordinators`` config.
+    Registry of coordinator instances loaded from ``[sdk]`` configurations.
 
-    Each entry in the JSON list takes the form::
+    The ``[sdk] coordinators`` value is a JSON object keyed by coordinator name::
 
         {
-            "name": "jdk-11",
-            "classpath": "airflow.sdk.coordinators.java.JavaCoordinator",
-            "kwargs": {"java_executable": "/usr/lib/jvm/jdk-11/bin/java", ...}
+            "jdk-11": {
+                "classpath": "airflow.sdk.coordinators.java.JavaCoordinator",
+                "kwargs": {"java_executable": "/usr/lib/jvm/jdk-11/bin/java", ...},
+            }
         }
 
     The ``classpath`` is resolved via
     :func:`~airflow.sdk._shared.module_loading.import_string` (no
-    :class:`ProvidersManager` involvement) and constructed with ``kwargs``.
+    :class:`ProvidersManager` involvement) and constructed with ``kwargs`` on
+    first use. A coordinator entry that is never looked up incurs no startup
+    cost. At most one coordinator object can be created from each entry.
 
-    The ``[sdk] queue_to_coordinator`` config maps queue names to a coordinator
-    ``name`` from that list, which lets users reuse existing queue assignments
-    to route tasks to a specific coordinator instance (for example, a
-    ``"legacy-java"`` queue routed to a JDK 11 coordinator and a
-    ``"modern-java"`` queue routed to a JDK 17 coordinator).
+    The ``[sdk] queue_to_coordinator`` config maps queue names to a key in the
+    object, which lets users reuse existing queue assignments to route tasks to
+    a specific coordinator instance (for example, a ``"legacy-java"`` queue
+    routed to a JDK 11 coordinator, and a ``"modern-java"`` queue routed to a
+    JDK 17 coordinator).
 
     :meta private:
     """
 
-    _queue_to_coordinator: Mapping[str, BaseCoordinator]
+    _coordinator_specs: Mapping[str, _CoordinatorSpec]
+    _queue_to_coordinator: Mapping[str, str]
+
+    _created_coordinators: dict[str, BaseCoordinator] = attrs.field(init=False, factory=dict)
 
     @classmethod
     def from_config(cls) -> Self:
-        """Load coordinator instances from the ``[sdk]`` configuration."""
-        from airflow.sdk.configuration import conf
-
-        coordinator_entry_list = conf.getjson("sdk", "coordinators", fallback=[])
-        if not isinstance(coordinator_entry_list, list):
-            coordinator_entries = {}
-        else:
-            coordinator_entries = {d["name"]: d for d in coordinator_entry_list if "name" in d}
-
-        queue_mapping = conf.getjson("sdk", "queue_to_coordinator", fallback={})
-        if not isinstance(queue_mapping, dict):
-            queue_mapping = {}
-
-        def _build_coordinator(key: str) -> BaseCoordinator:
-            entry = coordinator_entries[key]
-            coordinator_cls = import_string(entry["classpath"])
-            return coordinator_cls(**entry["kwargs"])
-
-        queue_to_coordinator = {
-            queue: _build_coordinator(coordinator_key)
-            for queue, coordinator_key in queue_mapping.items()
-            if coordinator_key in coordinator_entries
+        """Load coordinator specs from configuration without initialization."""
+        coordinator_specs = {
+            k: _CoordinatorSpec.model_validate(v)
+            for k, v in conf.getjson("sdk", "coordinators", fallback={}).items()
         }
-        return cls(queue_to_coordinator)
+        queue_to_coordinator = conf.getjson("sdk", "queue_to_coordinator", fallback={})
+        for key in queue_to_coordinator.values():
+            if key not in coordinator_specs:
+                raise ValueError(f"[sdk] queue_to_coordinator references invalid coordinator key: {key!r}")
+        return cls(coordinator_specs=coordinator_specs, queue_to_coordinator=queue_to_coordinator)
+
+    def _for_queue_internal(self, queue: str) -> BaseCoordinator:
+        key = self._queue_to_coordinator[queue]
+        with contextlib.suppress(KeyError):
+            return self._created_coordinators[key]
+        spec = self._coordinator_specs[key]
+        coordinator = self._created_coordinators[key] = import_string(spec.classpath)(**spec.kwargs)
+        return coordinator
 
     def for_queue(self, queue: str) -> BaseCoordinator:
         """
@@ -199,7 +214,10 @@ class CoordinatorManager:
 
         If an entry is not registered, a Python coordinator is returned.
         """
-        return self._queue_to_coordinator.get(queue) or _build_python_coordinator()
+        try:
+            return self._for_queue_internal(queue)
+        except KeyError:
+            return _build_python_coordinator()
 
 
 @functools.cache
@@ -211,11 +229,3 @@ def get_coordinator_manager() -> CoordinatorManager:
 def reset_coordinator_manager() -> None:
     """Clear the cached :class:`CoordinatorManager` (test helper)."""
     get_coordinator_manager.cache_clear()
-
-
-__all__ = [
-    "BaseCoordinator",
-    "CoordinatorManager",
-    "get_coordinator_manager",
-    "reset_coordinator_manager",
-]

--- a/task-sdk/tests/task_sdk/execution_time/test_coordinator.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_coordinator.py
@@ -22,6 +22,7 @@ import json
 
 import pytest
 
+from airflow.sdk.configuration import conf
 from airflow.sdk.execution_time.coordinator import (
     BaseCoordinator,
     CoordinatorManager,
@@ -40,6 +41,32 @@ class _CoordinatorB(BaseCoordinator):
     pass
 
 
+@pytest.fixture
+def sdk_config(monkeypatch):
+    """Set the ``[sdk]`` env vars consumed by :meth:`CoordinatorManager.from_config`.
+
+    :return: Callable ``apply(*, coordinators=None, queue_to_coordinator=None)`` --
+        each argument is the raw JSON string for the matching env var, or ``None``
+        to unset it. The conf cache is invalidated after each call (and again on
+        teardown) so ``from_config()`` re-reads the values just set.
+    """
+    from airflow.sdk.configuration import conf
+
+    def _apply(*, coordinators: str | None = None, queue_to_coordinator: str | None = None) -> None:
+        if coordinators is None:
+            monkeypatch.delenv("AIRFLOW__SDK__COORDINATORS", raising=False)
+        else:
+            monkeypatch.setenv("AIRFLOW__SDK__COORDINATORS", coordinators)
+        if queue_to_coordinator is None:
+            monkeypatch.delenv("AIRFLOW__SDK__QUEUE_TO_COORDINATOR", raising=False)
+        else:
+            monkeypatch.setenv("AIRFLOW__SDK__QUEUE_TO_COORDINATOR", queue_to_coordinator)
+        conf.invalidate_cache()
+
+    yield _apply
+    conf.invalidate_cache()
+
+
 class TestCoordinatorManager:
     @pytest.fixture(autouse=True)
     def _reset_cache(self):
@@ -47,55 +74,41 @@ class TestCoordinatorManager:
         yield
         reset_coordinator_manager()
 
-    def test_from_config_loads_instances(self, monkeypatch):
-        coordinators_json = json.dumps(
-            [
+    def test_from_config_loads_specs_and_resolves_instances(self, sdk_config):
+        sdk_config(
+            coordinators=json.dumps(
                 {
-                    "name": "alpha",
-                    "classpath": f"{_CoordinatorA.__module__}._CoordinatorA",
-                    "kwargs": {"label": "alpha-label"},
-                },
-                {
-                    "name": "beta",
-                    "classpath": f"{_CoordinatorB.__module__}._CoordinatorB",
-                },
-            ]
+                    "alpha": {
+                        "classpath": f"{_CoordinatorA.__module__}._CoordinatorA",
+                        "kwargs": {"label": "alpha-label"},
+                    },
+                    "beta": {"classpath": f"{_CoordinatorB.__module__}._CoordinatorB", "kwargs": {}},
+                }
+            ),
+            queue_to_coordinator=json.dumps({"queue-a": "alpha"}),
         )
-        queue_json = json.dumps({"queue-a": "alpha"})
-
-        monkeypatch.setenv("AIRFLOW__SDK__COORDINATORS", coordinators_json)
-        monkeypatch.setenv("AIRFLOW__SDK__QUEUE_TO_COORDINATOR", queue_json)
-
-        from airflow.sdk.configuration import conf
-
-        conf.invalidate_cache()
-
         manager = CoordinatorManager.from_config()
-        assert list(manager._queue_to_coordinator) == ["queue-a"]
+        assert manager._queue_to_coordinator == {"queue-a": "alpha"}
+        assert manager._created_coordinators == {}
 
         coordinator_for_queue_a = manager.for_queue("queue-a")
         assert isinstance(coordinator_for_queue_a, _CoordinatorA)
-        assert coordinator_for_queue_a.label == "alpha-label"
+        assert manager.for_queue("queue-a") is coordinator_for_queue_a, "instance should be cached"
+        assert manager._created_coordinators == {"alpha": coordinator_for_queue_a}
+
+        coordinator_for_queue_missing = manager.for_queue("queue-1")
+        assert isinstance(coordinator_for_queue_missing, _PythonCoordinator)
+        assert manager.for_queue("queue-1") is coordinator_for_queue_missing
+        assert manager._created_coordinators == {"alpha": coordinator_for_queue_a}
 
     def test_from_config_empty(self, monkeypatch):
         monkeypatch.delenv("AIRFLOW__SDK__COORDINATORS", raising=False)
         monkeypatch.delenv("AIRFLOW__SDK__QUEUE_TO_COORDINATOR", raising=False)
-
-        from airflow.sdk.configuration import conf
-
         conf.invalidate_cache()
 
         manager = CoordinatorManager.from_config()
+        assert manager._coordinator_specs == {}
         assert manager._queue_to_coordinator == {}
-
-    def test_for_queue_resolves_via_mapping(self):
-        coordinator_a = _CoordinatorA()
-        coordinator_b = _CoordinatorB()
-        manager = CoordinatorManager({"queue-a": coordinator_a, "queue-b": coordinator_b})
-
-        assert manager.for_queue("queue-a") is coordinator_a
-        assert manager.for_queue("queue-b") is coordinator_b
-        assert isinstance(manager.for_queue("queue-missing"), _PythonCoordinator)
 
     def test_get_coordinator_manager_is_cached(self, monkeypatch):
         monkeypatch.delenv("AIRFLOW__SDK__COORDINATORS", raising=False)


### PR DESCRIPTION
- first part of https://github.com/apache/airflow/issues/66836
- next one: https://github.com/astronomer/airflow/pull/1584

### What

- `[sdk] coordinators` is now a dict (accepting coordinator name as key and constructor config as value) instead of list.
- Support lazy initialization for coordinator. That `CoordinatorManager` will first check against the `[sdk] coordinators` and `[sdk] queue_to_coordinator` mapping before initializing the actual coordinator instance.