### PR TITLE
CI: Fix rat lisense

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -327,6 +327,11 @@ www-hash.txt
 # Vendored-in code
 /src/airflow/providers/google/_vendor/*
 
+# Java SDK build outputs
+/java-sdk/build/*
+/java-sdk/sdk/build/*
+/java-sdk/example/build/*
+
 # Git ignore file
 .gitignore
 

--- a/java-sdk/sdk/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/java-sdk/sdk/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,1 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
 org.apache.airflow.sdk.BuilderProcessor


### PR DESCRIPTION
### Why

Fix static check for `feature/java-sdk` branch.

### What

Example failure: https://github.com/apache/airflow/actions/runs/25499074526/job/74830470748?pr=65956

```
Check if licenses are OK for Apache.......................................................................Failed
- hook id: check-apache-license-rat
- exit code: 1

  Running command:
  docker run -v /home/runner/work/airflow/airflow:/opt/airflow -t --user 1001:1001 --rm ghcr.io/apache/airflow-apache-rat:0.17-2025.10.24@sha256:63e965ecfa195d38cf0525b16ad801dff75833ee97d88cd763020537c36981c9 --input-exclude-file /opt/airflow/.rat-excludes /opt/airflow

  ERROR: 1 when running rat

  ! Unapproved:         1    A count of unapproved licenses.
  ! /java-sdk/sdk/src/main/resources/META-INF/services/javax.annotation.processing.Processor
```

Additionally, we should add the build directories in `.rat-excludes` to avoid static check error when running `prek --all-files`.