### PR TITLE
Add optional serialized lineage channel

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py
@@ -106,6 +106,8 @@ class TISuccessStatePayload(StrictBaseModel):
 
     task_outlets: Annotated[list[AssetProfile], Field(default_factory=list)]
     outlet_events: Annotated[list[dict[str, Any]], Field(default_factory=list)]
+    serialized_lineage: JsonValue | None = None
+    """Optional serialized lineage payload reported by non-Python SDKs."""
     rendered_map_index: str | None = None
 
 

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -405,7 +405,13 @@ def ti_update_state(
 
     # We exclude_unset to avoid updating fields that are not set in the payload
     data = ti_patch_payload.model_dump(
-        exclude={"task_outlets", "outlet_events", "retry_delay_seconds", "retry_reason"},
+        exclude={
+            "task_outlets",
+            "outlet_events",
+            "serialized_lineage",
+            "retry_delay_seconds",
+            "retry_reason",
+        },
         exclude_unset=True,
     )
     query = update(TI).where(TI.id == task_instance_id).values(data)

--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/__init__.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/__init__.py
@@ -45,11 +45,14 @@ from airflow.api_fastapi.execution_api.versions.v2026_04_17 import (
     AddStateEndpoints,
     AddTeamNameField,
 )
-from airflow.api_fastapi.execution_api.versions.v2026_06_16 import AddRetryPolicyFields
+from airflow.api_fastapi.execution_api.versions.v2026_06_16 import (
+    AddRetryPolicyFields,
+    AddSerializedLineageToTaskSuccess,
+)
 
 bundle = VersionBundle(
     HeadVersion(),
-    Version("2026-06-16", AddRetryPolicyFields),
+    Version("2026-06-16", AddSerializedLineageToTaskSuccess, AddRetryPolicyFields),
     Version(
         "2026-04-17",
         AddTeamNameField,

--- a/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_06_16.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_06_16.py
@@ -19,7 +19,10 @@ from __future__ import annotations
 
 from cadwyn import VersionChange, schema
 
-from airflow.api_fastapi.execution_api.datamodels.taskinstance import TIRetryStatePayload
+from airflow.api_fastapi.execution_api.datamodels.taskinstance import (
+    TIRetryStatePayload,
+    TISuccessStatePayload,
+)
 
 
 class AddRetryPolicyFields(VersionChange):
@@ -30,4 +33,14 @@ class AddRetryPolicyFields(VersionChange):
     instructions_to_migrate_to_previous_version = (
         schema(TIRetryStatePayload).field("retry_delay_seconds").didnt_exist,
         schema(TIRetryStatePayload).field("retry_reason").didnt_exist,
+    )
+
+
+class AddSerializedLineageToTaskSuccess(VersionChange):
+    """Add optional serialized lineage payload to task success state updates."""
+
+    description = __doc__
+
+    instructions_to_migrate_to_previous_version = (
+        schema(TISuccessStatePayload).field("serialized_lineage").didnt_exist,
     )

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -1246,6 +1246,7 @@ class TestTIUpdateState:
                 "end_date": DEFAULT_END_DATE.isoformat(),
                 "task_outlets": task_outlets,
                 "outlet_events": outlet_events,
+                "serialized_lineage": {"runId": "123"},
             },
         )
 

--- a/task-sdk/src/airflow/sdk/api/client.py
+++ b/task-sdk/src/airflow/sdk/api/client.py
@@ -285,12 +285,21 @@ class TaskInstanceOperations:
         )
         self.client.patch(f"task-instances/{id}/state", content=body.model_dump_json())
 
-    def succeed(self, id: uuid.UUID, when: datetime, task_outlets, outlet_events, rendered_map_index):
+    def succeed(
+        self,
+        id: uuid.UUID,
+        when: datetime,
+        task_outlets,
+        outlet_events,
+        rendered_map_index,
+        serialized_lineage=None,
+    ):
         """Tell the API server that this TI has succeeded."""
         body = TISuccessStatePayload(
             end_date=when,
             task_outlets=task_outlets,
             outlet_events=outlet_events,
+            serialized_lineage=serialized_lineage,
             rendered_map_index=rendered_map_index,
         )
         self.client.patch(f"task-instances/{id}/state", content=body.model_dump_json())

--- a/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
+++ b/task-sdk/src/airflow/sdk/api/datamodels/_generated.py
@@ -324,6 +324,7 @@ class TISuccessStatePayload(BaseModel):
     end_date: Annotated[AwareDatetime, Field(title="End Date")]
     task_outlets: Annotated[list[AssetProfile] | None, Field(title="Task Outlets")] = None
     outlet_events: Annotated[list[dict[str, Any]] | None, Field(title="Outlet Events")] = None
+    serialized_lineage: JsonValue | None = None
     rendered_map_index: Annotated[str | None, Field(title="Rendered Map Index")] = None
 
 

--- a/task-sdk/src/airflow/sdk/execution_time/coordinator.py
+++ b/task-sdk/src/airflow/sdk/execution_time/coordinator.py
@@ -49,7 +49,10 @@ import selectors
 import socket
 import subprocess
 import time
-from typing import TYPE_CHECKING, NamedTuple
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, NamedTuple
+
+import msgspec
 
 from airflow.sdk._shared.module_loading import import_string, qualname
 
@@ -98,6 +101,7 @@ def _bridge(
     runtime_stderr: socket.socket,
     proc: subprocess.Popen,
     log: FilteringBoundLogger,
+    lineage_payload_handler: Callable[[Any], None] | None = None,
 ) -> None:
     """
     Multiplex I/O between the supervisor and a runtime subprocess.
@@ -133,7 +137,11 @@ def _bridge(
 
     # Comm: bidirectional raw byte forwarding.
     sel.register(supervisor_comm, selectors.EVENT_READ, make_raw_forwarder(runtime_comm, on_close))
-    sel.register(runtime_comm, selectors.EVENT_READ, make_raw_forwarder(supervisor_comm, on_close))
+    sel.register(
+        runtime_comm,
+        selectors.EVENT_READ,
+        _make_lineage_observing_forwarder(supervisor_comm, on_close, lineage_payload_handler),
+    )
 
     # TCP logs channel: line-buffered JSON from the runtime SDK's LogSender,
     # processed with the same handler as WatchedSubprocess (level mapping,
@@ -170,6 +178,50 @@ def _bridge(
     for sock in (supervisor_comm, runtime_comm, runtime_logs, runtime_stderr):
         with contextlib.suppress(OSError):
             sock.close()
+
+
+def _make_lineage_observing_forwarder(
+    dest: socket.socket,
+    on_close: Callable[[socket.socket], None],
+    lineage_payload_handler: Callable[[Any], None] | None,
+) -> tuple[Callable[[socket.socket], bool], Callable[[socket.socket], None]]:
+    """Forward raw comm bytes while observing optional success lineage payloads."""
+    buffer = bytearray()
+
+    def _observe(data: bytes) -> None:
+        if lineage_payload_handler is None:
+            return
+
+        buffer.extend(data)
+        while len(buffer) >= 4:
+            length = int.from_bytes(buffer[:4], byteorder="big")
+            if len(buffer) < length + 4:
+                return
+            frame = bytes(buffer[4 : length + 4])
+            del buffer[: length + 4]
+            try:
+                unpacked = msgspec.msgpack.decode(frame)
+                body = unpacked[1] if isinstance(unpacked, (list, tuple)) and len(unpacked) > 1 else None
+                if isinstance(body, dict) and body.get("type") == "SucceedTask":
+                    payload = body.get("serialized_lineage")
+                    if payload is not None:
+                        lineage_payload_handler(payload)
+            except Exception:
+                buffer.clear()
+                return
+
+    def cb(sock: socket.socket) -> bool:
+        data = sock.recv(65536)
+        if not data:
+            return False
+        try:
+            dest.sendall(data)
+            _observe(data)
+        except (BrokenPipeError, ConnectionResetError, OSError):
+            return False
+        return True
+
+    return cb, on_close
 
 
 class BaseCoordinator:
@@ -244,6 +296,15 @@ class BaseCoordinator:
         :returns: Full command list.
         """
         raise NotImplementedError
+
+    def handle_serialized_lineage(self, payload: Any) -> None:
+        """
+        Handle serialized lineage emitted by a runtime SDK task.
+
+        Runtime SDKs send this optional payload in ``SucceedTask.serialized_lineage``.
+        The base hook is intentionally a no-op so SDKs that do not emit lineage
+        keep the same wire traffic and coordinator behavior.
+        """
 
     def run_task_execution(
         self,
@@ -379,7 +440,15 @@ class BaseCoordinator:
             # fd 0 is the bidirectional comms socket to the supervisor.
             supervisor_comm = socket.socket(fileno=os.dup(0))
 
-            _bridge(supervisor_comm, runtime_comm, runtime_logs, read_stderr, proc, log)
+            _bridge(
+                supervisor_comm,
+                runtime_comm,
+                runtime_logs,
+                read_stderr,
+                proc,
+                log,
+                self.handle_serialized_lineage,
+            )
 
 
 class CoordinatorManager:

--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -1415,6 +1415,7 @@ class ActivitySubprocess(WatchedSubprocess):
                 when=msg.end_date,
                 task_outlets=msg.task_outlets,
                 outlet_events=msg.outlet_events,
+                serialized_lineage=msg.serialized_lineage,
                 rendered_map_index=self._rendered_map_index,
             )
         elif isinstance(msg, RetryTask):

--- a/task-sdk/tests/task_sdk/api/test_client.py
+++ b/task-sdk/tests/task_sdk/api/test_client.py
@@ -406,6 +406,31 @@ class TestTaskInstanceOperations:
             ti_id, state=state, when="2024-10-31T12:00:00Z", rendered_map_index="test"
         )
 
+    def test_task_instance_succeed_with_serialized_lineage(self):
+        ti_id = uuid6.uuid7()
+
+        def handle_request(request: httpx.Request) -> httpx.Response:
+            if request.url.path == f"/task-instances/{ti_id}/state":
+                actual_body = json.loads(request.read())
+                assert actual_body["end_date"] == "2024-10-31T12:00:00Z"
+                assert actual_body["state"] == "success"
+                assert actual_body["task_outlets"] == []
+                assert actual_body["outlet_events"] == []
+                assert actual_body["rendered_map_index"] == "test"
+                assert actual_body["serialized_lineage"] == {"runId": "123"}
+                return httpx.Response(status_code=204)
+            return httpx.Response(status_code=400, json={"detail": "Bad Request"})
+
+        client = make_client(transport=httpx.MockTransport(handle_request))
+        client.task_instances.succeed(
+            ti_id,
+            when=datetime(2024, 10, 31, 12, 0, tzinfo=timezone.utc),
+            task_outlets=[],
+            outlet_events=[],
+            rendered_map_index="test",
+            serialized_lineage={"runId": "123"},
+        )
+
     def test_task_instance_heartbeat(self):
         # Simulate a successful response from the server that sends a heartbeat for a ti
         ti_id = uuid6.uuid7()

--- a/task-sdk/tests/task_sdk/execution_time/test_coordinator.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_coordinator.py
@@ -22,15 +22,18 @@ import json
 import os
 import socket
 import subprocess
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from airflow.sdk.execution_time.comms import SucceedTask, _RequestFrame
 from airflow.sdk.execution_time.coordinator import (
     BaseCoordinator,
     CoordinatorManager,
     _bridge,
+    _make_lineage_observing_forwarder,
     _send_startup_details,
     _start_server,
     get_coordinator_manager,
@@ -168,6 +171,9 @@ class TestBaseCoordinatorDefaults:
                 logs_addr="127.0.0.1:1235",
             )
 
+    def test_handle_serialized_lineage_is_noop_by_default(self):
+        assert BaseCoordinator().handle_serialized_lineage({"openlineage": {}}) is None
+
 
 class TestCoordinatorNamedTuples:
     def test_dag_parsing_info_defaults(self):
@@ -194,6 +200,58 @@ class TestCoordinatorNamedTuples:
         assert info.mode == "task-execution"
         assert info.what is mock_ti
         assert info.dag_rel_path == "dags/example.jar"
+
+
+class TestLineageObservingForwarder:
+    def test_forwards_bytes_and_observes_success_lineage_payload(self):
+        src_write, src_read = socket.socketpair()
+        dest_read, dest_write = socket.socketpair()
+        observed = []
+
+        payload = {"runId": "123"}
+        frame = _RequestFrame(
+            1,
+            SucceedTask(
+                end_date=datetime(2024, 10, 31, 12, 0, tzinfo=timezone.utc),
+                serialized_lineage=payload,
+            ).model_dump(),
+        ).as_bytes()
+        cb, _ = _make_lineage_observing_forwarder(dest_write, lambda _: None, observed.append)
+
+        try:
+            src_write.sendall(frame)
+
+            assert cb(src_read) is True
+
+            assert dest_read.recv(len(frame)) == frame
+            assert observed == [payload]
+        finally:
+            for sock in (src_write, src_read, dest_read, dest_write):
+                with contextlib.suppress(OSError):
+                    sock.close()
+
+    def test_does_not_call_handler_without_lineage_payload(self):
+        src_write, src_read = socket.socketpair()
+        dest_read, dest_write = socket.socketpair()
+        observed = []
+
+        frame = _RequestFrame(
+            1,
+            SucceedTask(end_date=datetime(2024, 10, 31, 12, 0, tzinfo=timezone.utc)).model_dump(),
+        ).as_bytes()
+        cb, _ = _make_lineage_observing_forwarder(dest_write, lambda _: None, observed.append)
+
+        try:
+            src_write.sendall(frame)
+
+            assert cb(src_read) is True
+
+            assert dest_read.recv(len(frame)) == frame
+            assert observed == []
+        finally:
+            for sock in (src_write, src_read, dest_read, dest_write):
+                with contextlib.suppress(OSError):
+                    sock.close()
 
 
 class TestBridge:

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -1874,9 +1874,29 @@ REQUEST_TEST_CASES = [
                 "task_outlets": None,
                 "when": timezone.parse("2024-10-31T12:00:00Z"),
                 "rendered_map_index": "test success task",
+                "serialized_lineage": None,
             },
         ),
         test_id="succeed_task",
+    ),
+    RequestTestCase(
+        message=SucceedTask(
+            end_date=timezone.parse("2024-10-31T12:00:00Z"),
+            rendered_map_index="test success task",
+            serialized_lineage={"runId": "123"},
+        ),
+        client_mock=ClientMock(
+            method_path="task_instances.succeed",
+            kwargs={
+                "id": TI_ID,
+                "outlet_events": None,
+                "task_outlets": None,
+                "when": timezone.parse("2024-10-31T12:00:00Z"),
+                "rendered_map_index": "test success task",
+                "serialized_lineage": {"runId": "123"},
+            },
+        ),
+        test_id="succeed_task_with_serialized_lineage",
     ),
     RequestTestCase(
         message=GetAssetByName(name="asset"),


### PR DESCRIPTION
## Summary

- Adds an optional `serialized_lineage` field to task success payloads and Task SDK client models.
- Forwards that field through supervisor success handling while keeping it excluded from `TaskInstance` DB updates.
- Adds a non-mutating coordinator bridge observer hook so runtime SDKs can send serialized lineage on `SucceedTask` without changing forwarded IPC bytes.
- Covers coordinator forwarding, Task SDK client payloads, supervisor dispatch, and execution API success state handling.

## Notes

This is targeted at the coordinator feature branch from apache/airflow#65958 because the Java coordinator code for apache/airflow#67111 is not on `main` yet.

Addresses apache/airflow#67111.

## Tests

- `uv run --project task-sdk pytest task-sdk/tests/task_sdk/execution_time/test_coordinator.py task-sdk/tests/task_sdk/api/test_client.py::TestTaskInstanceOperations::test_task_instance_succeed_with_serialized_lineage task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[succeed_task] task-sdk/tests/task_sdk/execution_time/test_supervisor.py::TestHandleRequest::test_handle_requests[succeed_task_with_serialized_lineage] -q`
- `uv run --project airflow-core pytest airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py::TestTIUpdateState::test_ti_update_state_to_success_with_asset_events -q`
- `uv run prek run --files airflow-core/src/airflow/api_fastapi/execution_api/datamodels/taskinstance.py airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py airflow-core/src/airflow/api_fastapi/execution_api/versions/__init__.py airflow-core/src/airflow/api_fastapi/execution_api/versions/v2026_06_16.py airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py task-sdk/src/airflow/sdk/api/client.py task-sdk/src/airflow/sdk/api/datamodels/_generated.py task-sdk/src/airflow/sdk/execution_time/coordinator.py task-sdk/src/airflow/sdk/execution_time/supervisor.py task-sdk/tests/task_sdk/api/test_client.py task-sdk/tests/task_sdk/execution_time/test_coordinator.py task-sdk/tests/task_sdk/execution_time/test_supervisor.py`
