### PR TITLE
Honor OTEL_TRACES_SAMPLER for DAG-run head sampling

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -514,6 +514,13 @@ def _emit_task_span(ti, state):
     if not isinstance(ti.context_carrier, dict):
         return
     dr_ctx = TraceContextTextMapPropagator().extract(ti.dag_run.context_carrier)
+    # Honor the head-sampling decision recorded in the dag_run carrier. As a
+    # child of the carrier this would also be suppressed by ParentBased
+    # sampling, but the explicit guard is robust and cheap. A valid-but-unsampled
+    # carrier means the run was head-sampled out; skip emission.
+    dr_span_context = trace.get_current_span(context=dr_ctx).get_span_context()
+    if dr_span_context.is_valid and not dr_span_context.trace_flags.sampled:
+        return
 
     ti_ctx = TraceContextTextMapPropagator().extract(ti.context_carrier)
     ti_span = trace.get_current_span(context=ti_ctx)

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -515,17 +515,12 @@ def _emit_task_span(ti, state):
         return
     dr_ctx = TraceContextTextMapPropagator().extract(ti.dag_run.context_carrier)
 
-    # Honor the single head-sampling decision recorded in the dag_run carrier
-    # Under a parent-based sampler, this child span would already be dropped
-    # every span in the run agrees with it. Under a parent-based sampler (the
-    # default, and parentbased_traceidratio) this child span would already be
-    # dropped by ParentBased; the explicit check also keeps emission consistent
-    # under non-parent-based samplers (e.g. always_on / traceidratio), which
-    # ignore the parent and would otherwise sample this span back in, and it
-    # short-circuits before we build the span. A valid-but-unsampled carrier
-    # means the run was head-sampled out; skip emission. An invalid/empty carrier
-    # (legacy DagRun, NULL/backfilled) falls through and still emits, preserving
-    # prior behavior.
+    # Skip if the run was head-sampled out, so every span in the run agrees with the
+    # carrier's decision. A parent-based sampler would already drop this child span,
+    # but the explicit check also covers non-parent-based samplers (which ignore the
+    # parent and would re-sample it in) and short-circuits before building the span.
+    # An invalid/empty carrier (legacy/NULL) recorded no decision, so it falls through
+    # and still emits — preserving prior behavior.
     dr_span_context = trace.get_current_span(context=dr_ctx).get_span_context()
     if dr_span_context.is_valid and not dr_span_context.trace_flags.sampled:
         return

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -514,10 +514,16 @@ def _emit_task_span(ti, state):
     if not isinstance(ti.context_carrier, dict):
         return
     dr_ctx = TraceContextTextMapPropagator().extract(ti.dag_run.context_carrier)
-    # Honor the head-sampling decision recorded in the dag_run carrier. As a
-    # child of the carrier this would also be suppressed by ParentBased
-    # sampling, but the explicit guard is robust and cheap. A valid-but-unsampled
-    # carrier means the run was head-sampled out; skip emission.
+    # Honor the single head-sampling decision recorded in the dag_run carrier so
+    # every span in the run agrees with it. Under a parent-based sampler (the
+    # default, and parentbased_traceidratio) this child span would already be
+    # dropped by ParentBased; the explicit check also keeps emission consistent
+    # under non-parent-based samplers (e.g. always_on / traceidratio), which
+    # ignore the parent and would otherwise sample this span back in, and it
+    # short-circuits before we build the span. A valid-but-unsampled carrier
+    # means the run was head-sampled out; skip emission. An invalid/empty carrier
+    # (legacy DagRun, NULL/backfilled) falls through and still emits, preserving
+    # prior behavior.
     dr_span_context = trace.get_current_span(context=dr_ctx).get_span_context()
     if dr_span_context.is_valid and not dr_span_context.trace_flags.sampled:
         return

--- a/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
+++ b/airflow-core/src/airflow/api_fastapi/execution_api/routes/task_instances.py
@@ -514,7 +514,9 @@ def _emit_task_span(ti, state):
     if not isinstance(ti.context_carrier, dict):
         return
     dr_ctx = TraceContextTextMapPropagator().extract(ti.dag_run.context_carrier)
-    # Honor the single head-sampling decision recorded in the dag_run carrier so
+
+    # Honor the single head-sampling decision recorded in the dag_run carrier
+    # Under a parent-based sampler, this child span would already be dropped
     # every span in the run agrees with it. Under a parent-based sampler (the
     # default, and parentbased_traceidratio) this child span would already be
     # dropped by ParentBased; the explicit check also keeps emission consistent

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -383,9 +383,7 @@ class DagRun(Base, LoggingMixin):
         self.triggering_user_name = triggering_user_name
         self.scheduled_by_job_id = None
         self.context_carrier: dict[str, str] = new_dagrun_trace_carrier(
-            task_span_detail_level=self.conf.get(TASK_SPAN_DETAIL_LEVEL_KEY, None),
-            dag_id=getattr(self, "dag_id", None),
-            run_type=getattr(self, "run_type", None),
+            task_span_detail_level=self.conf.get(TASK_SPAN_DETAIL_LEVEL_KEY, None)
         )
 
         if not isinstance(partition_key, str | None):

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -383,7 +383,9 @@ class DagRun(Base, LoggingMixin):
         self.triggering_user_name = triggering_user_name
         self.scheduled_by_job_id = None
         self.context_carrier: dict[str, str] = new_dagrun_trace_carrier(
-            task_span_detail_level=self.conf.get(TASK_SPAN_DETAIL_LEVEL_KEY, None)
+            task_span_detail_level=self.conf.get(TASK_SPAN_DETAIL_LEVEL_KEY, None),
+            dag_id=getattr(self, "dag_id", None),
+            run_type=getattr(self, "run_type", None),
         )
 
         if not isinstance(partition_key, str | None):
@@ -1072,6 +1074,15 @@ class DagRun(Base, LoggingMixin):
         ctx = TraceContextTextMapPropagator().extract(self.context_carrier)
         span = trace.get_current_span(context=ctx)
         span_context = span.get_span_context()
+        # Honor the head-sampling decision recorded in the carrier. This is
+        # required because the span below is forced to be a root span
+        # (context=context.Context()), so the configured sampler would never see
+        # the carrier's flag otherwise. A valid-but-unsampled carrier means the
+        # run was head-sampled out; skip emission. An invalid/empty carrier
+        # (legacy DagRun created before tracing, NULL/backfilled) falls through
+        # and still emits a root span, preserving prior behavior.
+        if span_context.is_valid and not span_context.trace_flags.sampled:
+            return
         with override_ids(span_context.trace_id, span_context.span_id):
             attributes: dict[str, str] = {
                 "airflow.dag_id": str(self.dag_id),

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -1073,13 +1073,12 @@ class DagRun(Base, LoggingMixin):
         span = trace.get_current_span(context=ctx)
         span_context = span.get_span_context()
 
-        # Honor the head-sampling decision recorded in the carrier. This is
-        # required because the span below is forced to be a root span
-        # (context=context.Context()), so otherwise, the configured sampler would never see
-        # the carrier's flag.
-        # A valid-but-unsampled carrier means the run was head-sampled out; skip emission.
-        # An invalid/empty carrier (legacy DagRun created before tracing) falls through
-        # and still emits a root span, which is the prior behavior but we should possibly reconsider.
+        # Skip if the run was head-sampled out. Unlike the task spans, this guard is
+        # required (not just an optimization): the span below is forced to be a root span
+        # (context=context.Context()), so the configured sampler never sees the carrier's
+        # flag. A valid-but-unsampled carrier means head-sampled out; an invalid/empty
+        # carrier (legacy DagRun) recorded no decision, so it falls through and still
+        # emits — prior behavior we may want to reconsider.
         if span_context.is_valid and not span_context.trace_flags.sampled:
             return
 

--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -1074,15 +1074,17 @@ class DagRun(Base, LoggingMixin):
         ctx = TraceContextTextMapPropagator().extract(self.context_carrier)
         span = trace.get_current_span(context=ctx)
         span_context = span.get_span_context()
+
         # Honor the head-sampling decision recorded in the carrier. This is
         # required because the span below is forced to be a root span
-        # (context=context.Context()), so the configured sampler would never see
-        # the carrier's flag otherwise. A valid-but-unsampled carrier means the
-        # run was head-sampled out; skip emission. An invalid/empty carrier
-        # (legacy DagRun created before tracing, NULL/backfilled) falls through
-        # and still emits a root span, preserving prior behavior.
+        # (context=context.Context()), so otherwise, the configured sampler would never see
+        # the carrier's flag.
+        # A valid-but-unsampled carrier means the run was head-sampled out; skip emission.
+        # An invalid/empty carrier (legacy DagRun created before tracing) falls through
+        # and still emits a root span, which is the prior behavior but we should possibly reconsider.
         if span_context.is_valid and not span_context.trace_flags.sampled:
             return
+
         with override_ids(span_context.trace_id, span_context.span_id):
             attributes: dict[str, str] = {
                 "airflow.dag_id": str(self.dag_id),
@@ -1100,13 +1102,14 @@ class DagRun(Base, LoggingMixin):
                 attributes["airflow.dag_run.logical_date"] = str(self.logical_date)
             if self.partition_key:
                 attributes["airflow.dag_run.partition_key"] = str(self.partition_key)
+
             # TODO: make the empty parent context optional. Default should be to
-            # nest the dag run span under the currently active parent span (by
-            # omitting `context` here); only use the empty `context.Context()` to
-            # force a root span when Airflow itself initiates the run (e.g. dag
-            # triggered via API, scheduler, or backfill). Today this forces a
-            # root span unconditionally.
-            # Tracked at https://github.com/apache/airflow/issues/67210
+            #  nest the dag run span under the currently active parent span (by
+            #  omitting `context` here); only use the empty `context.Context()` to
+            #  force a root span when Airflow itself initiates the run (e.g. dag
+            #  triggered via API, scheduler, or backfill). Today this forces a
+            #  root span unconditionally.
+            #  Tracked at https://github.com/apache/airflow/issues/67210
             span = tracer.start_span(
                 name=f"dag_run.{self.dag_id}",
                 start_time=int((self.queued_at or self.start_date or timezone.utcnow()).timestamp() * 1e9),

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -429,7 +429,9 @@ def clear_task_instances(
             dr.clear_number += 1
             dr.queued_at = timezone.utcnow()
             dr.context_carrier = new_dagrun_trace_carrier(
-                task_span_detail_level=dr.conf.get(TASK_SPAN_DETAIL_LEVEL_KEY) if dr.conf else None
+                task_span_detail_level=dr.conf.get(TASK_SPAN_DETAIL_LEVEL_KEY) if dr.conf else None,
+                dag_id=getattr(dr, "dag_id", None),
+                run_type=getattr(dr, "run_type", None),
             )
 
             _recalculate_dagrun_queued_at_deadlines(dr, dr.queued_at, session)

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -429,9 +429,7 @@ def clear_task_instances(
             dr.clear_number += 1
             dr.queued_at = timezone.utcnow()
             dr.context_carrier = new_dagrun_trace_carrier(
-                task_span_detail_level=dr.conf.get(TASK_SPAN_DETAIL_LEVEL_KEY) if dr.conf else None,
-                dag_id=getattr(dr, "dag_id", None),
-                run_type=getattr(dr, "run_type", None),
+                task_span_detail_level=dr.conf.get(TASK_SPAN_DETAIL_LEVEL_KEY) if dr.conf else None
             )
 
             _recalculate_dagrun_queued_at_deadlines(dr, dr.queued_at, session)

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -4061,3 +4061,21 @@ class TestEmitTaskSpan:
 
         _emit_task_span(ti, TaskInstanceState.SUCCESS)
         assert len(self.exporter.get_finished_spans()) == 0
+
+    def test_emit_task_span_emits_when_dagrun_carrier_sampled(self):
+        """A SAMPLED dag_run carrier should allow the task span to emit."""
+        ti = self._make_ti()
+        # _make_carriers uses a default provider -> SAMPLED flag is set.
+        dr_ctx = TraceContextTextMapPropagator().extract(ti.dag_run.context_carrier)
+        assert otel_trace.get_current_span(dr_ctx).get_span_context().trace_flags.sampled
+        _emit_task_span(ti, TaskInstanceState.SUCCESS)
+        assert len(self.exporter.get_finished_spans()) == 1
+
+    def test_emit_task_span_skips_when_dagrun_carrier_unsampled(self):
+        """A valid-but-unsampled dag_run carrier (flag 00) means the run was head-sampled out."""
+        ti = self._make_ti()
+        ti.dag_run.context_carrier = {
+            "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00"
+        }
+        _emit_task_span(ti, TaskInstanceState.SUCCESS)
+        assert len(self.exporter.get_finished_spans()) == 0

--- a/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
+++ b/airflow-core/tests/unit/api_fastapi/execution_api/versions/head/test_task_instances.py
@@ -4062,20 +4062,18 @@ class TestEmitTaskSpan:
         _emit_task_span(ti, TaskInstanceState.SUCCESS)
         assert len(self.exporter.get_finished_spans()) == 0
 
-    def test_emit_task_span_emits_when_dagrun_carrier_sampled(self):
-        """A SAMPLED dag_run carrier should allow the task span to emit."""
-        ti = self._make_ti()
-        # _make_carriers uses a default provider -> SAMPLED flag is set.
-        dr_ctx = TraceContextTextMapPropagator().extract(ti.dag_run.context_carrier)
-        assert otel_trace.get_current_span(dr_ctx).get_span_context().trace_flags.sampled
-        _emit_task_span(ti, TaskInstanceState.SUCCESS)
-        assert len(self.exporter.get_finished_spans()) == 1
-
-    def test_emit_task_span_skips_when_dagrun_carrier_unsampled(self):
-        """A valid-but-unsampled dag_run carrier (flag 00) means the run was head-sampled out."""
+    @pytest.mark.parametrize(
+        ("trace_flag", "expected_spans"),
+        [
+            pytest.param("01", 1, id="sampled-carrier-emits"),
+            pytest.param("00", 0, id="unsampled-carrier-skips"),
+        ],
+    )
+    def test_emit_task_span_honors_dagrun_carrier_sampling(self, trace_flag, expected_spans):
+        """A SAMPLED dag_run carrier (flag 01) emits the task span; an unsampled one (flag 00) is head-sampled out."""
         ti = self._make_ti()
         ti.dag_run.context_carrier = {
-            "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00"
+            "traceparent": f"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-{trace_flag}"
         }
         _emit_task_span(ti, TaskInstanceState.SUCCESS)
-        assert len(self.exporter.get_finished_spans()) == 0
+        assert len(self.exporter.get_finished_spans()) == expected_spans

--- a/airflow-core/tests/unit/models/test_dagrun.py
+++ b/airflow-core/tests/unit/models/test_dagrun.py
@@ -1535,7 +1535,6 @@ class TestDagRun:
 
     @mock.patch.object(Deadline, "prune_deadlines")
     def test_dagrun_deadline_variable_interval_missing_variable_fails(self, _, session, deadline_test_dag):
-
         mock_err = mock.Mock()
         mock_err.error.value = "MISSING_DEADLINE"
         mock_err.detail = "missing deadline"
@@ -4186,41 +4185,33 @@ class TestDagRunTracing:
         else:
             assert len(spans) == 0
 
-    def test_emit_dagrun_span_emits_when_carrier_sampled(self, dag_maker, session):
-        """A SAMPLED carrier (flag 01) should emit the dag_run span."""
+    @pytest.mark.parametrize(
+        ("dag_id", "trace_flag", "expected_spans"),
+        [
+            pytest.param("test_tracing_sampled", "01", 1, id="sampled-carrier-emits"),
+            pytest.param("test_tracing_unsampled", "00", 0, id="unsampled-carrier-skips"),
+        ],
+    )
+    def test_emit_dagrun_span_honors_carrier_sampling(
+        self, dag_id, trace_flag, expected_spans, dag_maker, session
+    ):
+        """A SAMPLED carrier (flag 01) emits the dag_run span; an unsampled carrier (flag 00) is head-sampled out."""
         in_mem_exporter = InMemorySpanExporter()
         provider = TracerProvider(id_generator=OverrideableRandomIdGenerator())
         provider.add_span_processor(SimpleSpanProcessor(in_mem_exporter))
         test_tracer = provider.get_tracer("test")
 
-        with dag_maker("test_tracing_sampled", session=session) as dag:
+        with dag_maker(dag_id, session=session) as dag:
             EmptyOperator(task_id="t1")
         dr = dag_maker.create_dagrun(state=DagRunState.RUNNING)
         dr.dag = dag
-        dr.context_carrier = {"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"}
+        traceparent = f"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-{trace_flag}"
+        dr.context_carrier = {"traceparent": traceparent}
 
         with mock.patch("airflow.models.dagrun.tracer", test_tracer):
             dr._emit_dagrun_span(state=DagRunState.SUCCESS)
 
-        assert len(in_mem_exporter.get_finished_spans()) == 1
-
-    def test_emit_dagrun_span_skips_when_carrier_unsampled(self, dag_maker, session):
-        """A valid-but-unsampled carrier (flag 00) means head-sampled out -> no span."""
-        in_mem_exporter = InMemorySpanExporter()
-        provider = TracerProvider(id_generator=OverrideableRandomIdGenerator())
-        provider.add_span_processor(SimpleSpanProcessor(in_mem_exporter))
-        test_tracer = provider.get_tracer("test")
-
-        with dag_maker("test_tracing_unsampled", session=session) as dag:
-            EmptyOperator(task_id="t1")
-        dr = dag_maker.create_dagrun(state=DagRunState.RUNNING)
-        dr.dag = dag
-        dr.context_carrier = {"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00"}
-
-        with mock.patch("airflow.models.dagrun.tracer", test_tracer):
-            dr._emit_dagrun_span(state=DagRunState.SUCCESS)
-
-        assert len(in_mem_exporter.get_finished_spans()) == 0
+        assert len(in_mem_exporter.get_finished_spans()) == expected_spans
 
     @pytest.mark.db_test
     def test_context_carrier_includes_detail_level_from_conf(self, dag_maker):

--- a/airflow-core/tests/unit/models/test_dagrun.py
+++ b/airflow-core/tests/unit/models/test_dagrun.py
@@ -4003,10 +4003,23 @@ class TestDagRunTracing:
 
     @pytest.fixture(autouse=True)
     def sdk_tracer_provider(self):
-        """Patch the module-level tracer with one backed by a real SDK provider so spans have valid IDs."""
+        """Patch the module-level tracer with one backed by a real SDK provider so spans have valid IDs.
+
+        Also patch the provider that ``new_dagrun_trace_carrier`` consults so the
+        head-sampling decision is made by a real SDK sampler (default
+        parentbased_always_on -> SAMPLED) rather than the no-op ProxyTracerProvider
+        that is otherwise active in the test process (which would honestly produce
+        an unsampled carrier and suppress emission).
+        """
         provider = TracerProvider()
         real_tracer = provider.get_tracer("airflow.models.dagrun")
-        with mock.patch("airflow.models.dagrun.tracer", real_tracer):
+        with (
+            mock.patch("airflow.models.dagrun.tracer", real_tracer),
+            mock.patch(
+                "airflow._shared.observability.traces.trace.get_tracer_provider",
+                return_value=provider,
+            ),
+        ):
             yield
 
     def test_context_carrier_set_on_init(self, dag_maker):
@@ -4172,6 +4185,42 @@ class TestDagRunTracing:
             assert spans[0].name == f"dag_run.{dr.dag_id}"
         else:
             assert len(spans) == 0
+
+    def test_emit_dagrun_span_emits_when_carrier_sampled(self, dag_maker, session):
+        """A SAMPLED carrier (flag 01) should emit the dag_run span."""
+        in_mem_exporter = InMemorySpanExporter()
+        provider = TracerProvider(id_generator=OverrideableRandomIdGenerator())
+        provider.add_span_processor(SimpleSpanProcessor(in_mem_exporter))
+        test_tracer = provider.get_tracer("test")
+
+        with dag_maker("test_tracing_sampled", session=session) as dag:
+            EmptyOperator(task_id="t1")
+        dr = dag_maker.create_dagrun(state=DagRunState.RUNNING)
+        dr.dag = dag
+        dr.context_carrier = {"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"}
+
+        with mock.patch("airflow.models.dagrun.tracer", test_tracer):
+            dr._emit_dagrun_span(state=DagRunState.SUCCESS)
+
+        assert len(in_mem_exporter.get_finished_spans()) == 1
+
+    def test_emit_dagrun_span_skips_when_carrier_unsampled(self, dag_maker, session):
+        """A valid-but-unsampled carrier (flag 00) means head-sampled out -> no span."""
+        in_mem_exporter = InMemorySpanExporter()
+        provider = TracerProvider(id_generator=OverrideableRandomIdGenerator())
+        provider.add_span_processor(SimpleSpanProcessor(in_mem_exporter))
+        test_tracer = provider.get_tracer("test")
+
+        with dag_maker("test_tracing_unsampled", session=session) as dag:
+            EmptyOperator(task_id="t1")
+        dr = dag_maker.create_dagrun(state=DagRunState.RUNNING)
+        dr.dag = dag
+        dr.context_carrier = {"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00"}
+
+        with mock.patch("airflow.models.dagrun.tracer", test_tracer):
+            dr._emit_dagrun_span(state=DagRunState.SUCCESS)
+
+        assert len(in_mem_exporter.get_finished_spans()) == 0
 
     @pytest.mark.db_test
     def test_context_carrier_includes_detail_level_from_conf(self, dag_maker):

--- a/shared/observability/src/airflow_shared/observability/traces/__init__.py
+++ b/shared/observability/src/airflow_shared/observability/traces/__init__.py
@@ -61,7 +61,7 @@ TASK_SPAN_DETAIL_LEVEL_KEY = "airflow/task_span_detail_level"
 DEFAULT_TASK_SPAN_DETAIL_LEVEL = 1
 
 
-def new_dagrun_trace_carrier(task_span_detail_level=None, dag_id=None, run_type=None) -> dict[str, str]:
+def new_dagrun_trace_carrier(task_span_detail_level=None) -> dict[str, str]:
     """
     Generate a fresh W3C traceparent carrier without creating a recordable span.
 
@@ -74,10 +74,6 @@ def new_dagrun_trace_carrier(task_span_detail_level=None, dag_id=None, run_type=
     Backcompat: when ``OTEL_TRACES_SAMPLER`` is unset the SDK defaults to
     ``parentbased_always_on`` whose root decision is ALWAYS_ON, so the flag is
     SAMPLED and behavior is identical to the previous hardcoded value.
-
-    ``dag_id`` / ``run_type`` are forwarded to the sampler as attributes so a
-    custom sampler can differentiate by run kind. They are optional so other
-    callers don't break.
     """
     gen = RandomIdGenerator()
     trace_id = gen.generate_trace_id()
@@ -85,16 +81,10 @@ def new_dagrun_trace_carrier(task_span_detail_level=None, dag_id=None, run_type=
     provider = trace.get_tracer_provider()
     sampler = getattr(provider, "sampler", None)
     if sampler is not None:
-        attributes = {}
-        if dag_id is not None:
-            attributes["airflow.dag_id"] = dag_id
-        if run_type is not None:
-            attributes["airflow.run_type"] = run_type
         result = sampler.should_sample(
             parent_context=None,  # root decision
             trace_id=trace_id,
             name="dag_run",
-            attributes=attributes,
         )
         sampled = result.decision == Decision.RECORD_AND_SAMPLE
         sampler_trace_state = result.trace_state

--- a/shared/observability/src/airflow_shared/observability/traces/__init__.py
+++ b/shared/observability/src/airflow_shared/observability/traces/__init__.py
@@ -28,6 +28,7 @@ from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, SpanExporter
 from opentelemetry.sdk.trace.id_generator import RandomIdGenerator
+from opentelemetry.sdk.trace.sampling import Decision
 from opentelemetry.trace import NonRecordingSpan, Span, SpanContext, TraceFlags, TraceState
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
@@ -60,16 +61,62 @@ TASK_SPAN_DETAIL_LEVEL_KEY = "airflow/task_span_detail_level"
 DEFAULT_TASK_SPAN_DETAIL_LEVEL = 1
 
 
-def new_dagrun_trace_carrier(task_span_detail_level=None) -> dict[str, str]:
-    """Generate a fresh W3C traceparent carrier without creating a recordable span."""
+def new_dagrun_trace_carrier(task_span_detail_level=None, dag_id=None, run_type=None) -> dict[str, str]:
+    """
+    Generate a fresh W3C traceparent carrier without creating a recordable span.
+
+    The SAMPLED flag is set from an honest *root* sampling decision made by the
+    configured tracer provider's sampler (driven by ``OTEL_TRACES_SAMPLER`` /
+    ``OTEL_TRACES_SAMPLER_ARG``), rather than being hardcoded. This makes the
+    carrier the single head-sampling decision point for a DAG run: every
+    downstream span (dag_run, task_run, worker) rides on this flag.
+
+    Backcompat: when ``OTEL_TRACES_SAMPLER`` is unset the SDK defaults to
+    ``parentbased_always_on`` whose root decision is ALWAYS_ON, so the flag is
+    SAMPLED and behavior is identical to the previous hardcoded value.
+
+    ``dag_id`` / ``run_type`` are forwarded to the sampler as attributes so a
+    custom sampler can differentiate by run kind. They are optional so other
+    callers don't break.
+    """
     gen = RandomIdGenerator()
-    trace_state_entries = build_trace_state_entries(task_span_detail_level)
+    trace_id = gen.generate_trace_id()
+
+    provider = trace.get_tracer_provider()
+    sampler = getattr(provider, "sampler", None)
+    if sampler is not None:
+        attributes = {}
+        if dag_id is not None:
+            attributes["airflow.dag_id"] = dag_id
+        if run_type is not None:
+            attributes["airflow.run_type"] = run_type
+        result = sampler.should_sample(
+            parent_context=None,  # root decision
+            trace_id=trace_id,
+            name="dag_run",
+            attributes=attributes,
+        )
+        sampled = result.decision == Decision.RECORD_AND_SAMPLE
+        sampler_trace_state = result.trace_state
+    else:
+        # No sampler attribute means a proxy/no-op provider (otel disabled).
+        # Nothing exports in that case, so the flag is irrelevant; mirror the
+        # observable behavior of today when otel is off.
+        sampled = False
+        sampler_trace_state = None
+
+    # Preserve the detail-level tracestate by merging it onto whatever the
+    # sampler returned. TraceState is immutable, so update() returns a new one.
+    trace_state = sampler_trace_state or TraceState()
+    for key, value in build_trace_state_entries(task_span_detail_level):
+        trace_state = trace_state.update(key, value)
+
     span_ctx = SpanContext(
-        trace_id=gen.generate_trace_id(),
+        trace_id=trace_id,
         span_id=gen.generate_span_id(),
         is_remote=False,
-        trace_flags=TraceFlags(TraceFlags.SAMPLED),
-        trace_state=TraceState(entries=trace_state_entries),
+        trace_flags=TraceFlags(TraceFlags.SAMPLED if sampled else 0),
+        trace_state=trace_state,
     )
     ctx = trace.set_span_in_context(NonRecordingSpan(span_ctx))
     carrier: dict[str, str] = {}

--- a/shared/observability/tests/observability/test_traces.py
+++ b/shared/observability/tests/observability/test_traces.py
@@ -170,28 +170,6 @@ class TestNewDagrunTraceCarrierSampling:
         assert get_task_span_detail_level(span) == 2
         assert _carrier_is_sampled(carrier) is False
 
-    def test_dag_id_and_run_type_passed_to_sampler(self, monkeypatch):
-        """dag_id/run_type are forwarded to the sampler as attributes for differentiation."""
-        captured = {}
-
-        class _RecordingSampler:
-            def should_sample(self, parent_context, trace_id, name, attributes=None, **kwargs):
-                captured["attributes"] = attributes
-                return ALWAYS_ON.should_sample(parent_context, trace_id, name, attributes=attributes)
-
-        class _Provider:
-            sampler = _RecordingSampler()
-
-        monkeypatch.setattr(
-            "airflow_shared.observability.traces.trace.get_tracer_provider",
-            lambda: _Provider(),
-        )
-        new_dagrun_trace_carrier(dag_id="my_dag", run_type="manual")
-        assert captured["attributes"] == {
-            "airflow.dag_id": "my_dag",
-            "airflow.run_type": "manual",
-        }
-
 
 class TestGetTaskSpanDetailLevel:
     def _make_span_with_trace_state(self, entries: list[tuple[str, str]]) -> NonRecordingSpan:

--- a/shared/observability/tests/observability/test_traces.py
+++ b/shared/observability/tests/observability/test_traces.py
@@ -17,6 +17,15 @@
 # under the License.
 from __future__ import annotations
 
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.sampling import (
+    ALWAYS_OFF,
+    ALWAYS_ON,
+    ParentBased,
+    TraceIdRatioBased,
+)
 from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags, TraceState
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
@@ -27,6 +36,11 @@ from airflow_shared.observability.traces import (
     get_task_span_detail_level,
     new_dagrun_trace_carrier,
 )
+
+
+def _carrier_is_sampled(carrier: dict[str, str]) -> bool:
+    ctx = TraceContextTextMapPropagator().extract(carrier)
+    return trace.get_current_span(ctx).get_span_context().trace_flags.sampled
 
 
 class TestBuildTraceStateEntries:
@@ -66,6 +80,117 @@ class TestNewDagrunTraceCarrier:
 
         span_ctx = trace.get_current_span(ctx).get_span_context()
         assert span_ctx.trace_state.get(TASK_SPAN_DETAIL_LEVEL_KEY) is None
+
+
+class TestNewDagrunTraceCarrierSampling:
+    """The carrier's SAMPLED flag should reflect the configured sampler's root decision."""
+
+    @pytest.fixture
+    def with_sampler(self, monkeypatch):
+        """Install a TracerProvider with the given sampler for new_dagrun_trace_carrier."""
+
+        def _install(sampler):
+            provider = TracerProvider(sampler=sampler)
+            monkeypatch.setattr(
+                "airflow_shared.observability.traces.trace.get_tracer_provider",
+                lambda: provider,
+            )
+
+        return _install
+
+    def test_no_sampler_provider_not_sampled(self, monkeypatch):
+        """A proxy/no-op provider (otel off) has no ``sampler`` attribute -> not sampled."""
+
+        class _NoSamplerProvider:
+            pass
+
+        monkeypatch.setattr(
+            "airflow_shared.observability.traces.trace.get_tracer_provider",
+            lambda: _NoSamplerProvider(),
+        )
+        assert _carrier_is_sampled(new_dagrun_trace_carrier()) is False
+
+    def test_default_provider_is_sampled(self):
+        """The SDK default provider (parentbased_always_on) samples the root -> backcompat."""
+        # No monkeypatching: rely on whatever default provider is configured.
+        # A bare TracerProvider() defaults to parentbased_always_on.
+        provider = TracerProvider()
+        assert provider.sampler is not None
+        result = provider.sampler.should_sample(parent_context=None, trace_id=1234, name="dag_run")
+        from opentelemetry.sdk.trace.sampling import Decision
+
+        assert result.decision == Decision.RECORD_AND_SAMPLE
+
+    def test_always_on_is_sampled(self, with_sampler):
+        with_sampler(ParentBased(ALWAYS_ON))
+        assert _carrier_is_sampled(new_dagrun_trace_carrier()) is True
+
+    def test_always_off_is_not_sampled(self, with_sampler):
+        with_sampler(ALWAYS_OFF)
+        assert _carrier_is_sampled(new_dagrun_trace_carrier()) is False
+
+    def test_traceidratio_is_deterministic_per_trace_id(self, with_sampler):
+        """A ratio sampler makes a deterministic decision keyed on trace_id."""
+        with_sampler(TraceIdRatioBased(0.5))
+        # Generate a batch; with ratio 0.5 we expect a mix, and each individual
+        # decision must be stable for its own trace_id.
+        carriers = [new_dagrun_trace_carrier() for _ in range(50)]
+        decisions = [_carrier_is_sampled(c) for c in carriers]
+        # Re-evaluating the same trace_id yields the same decision (determinism):
+        sampler = TraceIdRatioBased(0.5)
+        from opentelemetry.sdk.trace.sampling import Decision
+
+        for carrier, decided in zip(carriers, decisions):
+            ctx = TraceContextTextMapPropagator().extract(carrier)
+            trace_id = trace.get_current_span(ctx).get_span_context().trace_id
+            redo = sampler.should_sample(parent_context=None, trace_id=trace_id, name="dag_run")
+            assert (redo.decision == Decision.RECORD_AND_SAMPLE) == decided
+        # Check: ratio 0.5 over 50 should produce a mix of both outcomes.
+        assert any(decisions)
+        assert not all(decisions)
+
+    def test_ratio_zero_never_sampled(self, with_sampler):
+        with_sampler(TraceIdRatioBased(0.0))
+        assert all(_carrier_is_sampled(new_dagrun_trace_carrier()) is False for _ in range(20))
+
+    def test_detail_level_roundtrips_when_sampled(self, with_sampler):
+        with_sampler(ParentBased(ALWAYS_ON))
+        carrier = new_dagrun_trace_carrier(task_span_detail_level=3)
+        ctx = TraceContextTextMapPropagator().extract(carrier)
+        span = trace.get_current_span(ctx)
+        assert get_task_span_detail_level(span) == 3
+        assert _carrier_is_sampled(carrier) is True
+
+    def test_detail_level_roundtrips_when_not_sampled(self, with_sampler):
+        """Detail-level tracestate must survive even for an unsampled carrier."""
+        with_sampler(ALWAYS_OFF)
+        carrier = new_dagrun_trace_carrier(task_span_detail_level=2)
+        ctx = TraceContextTextMapPropagator().extract(carrier)
+        span = trace.get_current_span(ctx)
+        assert get_task_span_detail_level(span) == 2
+        assert _carrier_is_sampled(carrier) is False
+
+    def test_dag_id_and_run_type_passed_to_sampler(self, monkeypatch):
+        """dag_id/run_type are forwarded to the sampler as attributes for differentiation."""
+        captured = {}
+
+        class _RecordingSampler:
+            def should_sample(self, parent_context, trace_id, name, attributes=None, **kwargs):
+                captured["attributes"] = attributes
+                return ALWAYS_ON.should_sample(parent_context, trace_id, name, attributes=attributes)
+
+        class _Provider:
+            sampler = _RecordingSampler()
+
+        monkeypatch.setattr(
+            "airflow_shared.observability.traces.trace.get_tracer_provider",
+            lambda: _Provider(),
+        )
+        new_dagrun_trace_carrier(dag_id="my_dag", run_type="manual")
+        assert captured["attributes"] == {
+            "airflow.dag_id": "my_dag",
+            "airflow.run_type": "manual",
+        }
 
 
 class TestGetTaskSpanDetailLevel:

--- a/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_task_runner.py
@@ -5423,6 +5423,24 @@ class TestTaskInstanceMetrics:
 class TestDetailSpan:
     """Tests for the detail_span decorator / context manager."""
 
+    @pytest.fixture(autouse=True)
+    def _sampled_carrier_provider(self):
+        """Make new_dagrun_trace_carrier produce a SAMPLED carrier.
+
+        new_dagrun_trace_carrier consults the global tracer provider's sampler to
+        decide the carrier's SAMPLED flag. In the test process the global provider
+        is a no-op ProxyTracerProvider (no sampler) -> unsampled carrier, which
+        would make the parent span (and its detail children) non-recording. Patch
+        the lookup to a real SDK provider whose default sampler
+        (parentbased_always_on) samples the root, mirroring "otel on" in production.
+        """
+        provider = TracerProvider()
+        with mock.patch(
+            "airflow._shared.observability.traces.trace.get_tracer_provider",
+            return_value=provider,
+        ):
+            yield
+
     def test_level_1_no_child_span_as_context_manager(self):
         """At detail level 1, entering detail_span should not create a real recorded span."""
         exporter = InMemorySpanExporter()


### PR DESCRIPTION
## Problem

`dag_run.context_carrier` hardcoded `TraceFlags(TraceFlags.SAMPLED)`. Because that carrier is the parent for every downstream span (`dag_run`, `task_run`, `worker`), the always-sampled remote parent poisoned parent-based sampling: a configured `OTEL_TRACES_SAMPLER` controlled nothing. The `dag_run` span (forced root) would drop, but `task_run`/`worker` spans kept flowing via `ParentBased -> remote_parent_sampled -> ALWAYS_ON`. There was no pure-config path to "default off, opt-in."

## The change

Make the carrier carry an **honest** head-sampling decision from the configured sampler, and honor that flag at emit time.

- **`new_dagrun_trace_carrier()`** now consults the configured tracer provider's sampler with a **ROOT** decision (`parent_context=None`) against the freshly generated `trace_id`, setting the `SAMPLED` flag only when the decision is `RECORD_AND_SAMPLE`. If the provider has no `sampler` attribute (proxy/no-op provider, i.e. otel off), it falls back to not-sampled — observably identical to today (nothing exports). `dag_id` / `run_type` are forwarded as sampler attributes so a custom sampler can differentiate by run kind. The detail-level `tracestate` is merged onto whatever the sampler returns, so it still round-trips through `get_task_span_detail_level`.
- **`_emit_dagrun_span`** honors the flag. This is **required**: the function forces a root span (`context=context.Context()`), so the sampler would otherwise never see the carrier's flag. A valid-but-unsampled carrier returns early; an invalid/empty carrier (legacy DagRun with NULL/empty `context_carrier`) still emits a root span as before.
- **`_emit_task_span`** honors the dag_run carrier's flag for consistency/safety (cheap explicit guard in addition to ParentBased).
- Threaded `dag_id` / `run_type` into both DagRun-based carrier call sites (`DagRun.__init__`, the clear path in `taskinstance.py`).

The worker span path (`_make_task_span`) needs **no change**: verified that with an unsampled remote parent carrier, `start_as_current_span` yields a non-recording span via the default `ParentBased` sampler (not exported); a sampled parent yields a recording span.

## Backcompat

When `OTEL_TRACES_SAMPLER` is unset, the SDK defaults to `parentbased_always_on`, whose root decision is `ALWAYS_ON`. So the flag is `SAMPLED` and behavior is identical to the previous hardcoded value — **no change for anyone who hasn't opted in.**

## Behavior matrix

| `OTEL_TRACES_SAMPLER` | Root decision | Result |
|---|---|---|
| *(unset)* | `parentbased_always_on` -> ALWAYS_ON | everything traced (same as today) |
| `always_on` | ALWAYS_ON | everything traced |
| `traceidratio` arg `0.05` | 5% by trace_id | head-sampled, deterministic per run |
| `always_off` | ALWAYS_OFF | nothing traced |
| otel off (`otel_on=False`) | no provider sampler -> `sampled=False` | nothing exports (same as today) |

## Tests

- `shared/observability/tests/observability/test_traces.py`: sampler-driven carrier flag (no-provider/default/always_on/always_off/traceidratio determinism/ratio 0), detail-level round-trip when sampled and unsampled, `dag_id`/`run_type` forwarded to sampler.
- `airflow-core/tests/unit/models/test_dagrun.py`: `_emit_dagrun_span` emits when carrier sampled, skips when unsampled; fixed the tracing fixture so the carrier is built via a real SDK provider (the test process otherwise has a no-op proxy provider that would honestly produce an unsampled carrier).
- `airflow-core/tests/unit/api_fastapi/execution_api/.../test_task_instances.py`: `_emit_task_span` emits when dag_run carrier sampled, skips when unsampled.
- `task-sdk/tests/task_sdk/execution_time/test_task_runner.py`: `TestDetailSpan` gets a fixture making the carrier sampled (same proxy-provider reason).

All passing: 20 observability, 13 dagrun tracing + 11 task-span, 5 detail-span, plus the clear-path/triggerer carrier tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)