### PR TITLE
Forward run-identity attributes to the trace sampler (ACD-177)

### DIFF
--- a/airflow-core/src/airflow/models/dagrun.py
+++ b/airflow-core/src/airflow/models/dagrun.py
@@ -152,6 +152,25 @@ def _creator_note(val):
     return DagRunNote(*val)
 
 
+def dagrun_trace_attributes(dr) -> dict[str, str]:
+    """
+    Run-identity attributes for a DAG run's trace.
+
+    Defined once and used in two places: forwarded to the sampler at carrier
+    creation (so a custom sampler can differentiate the head-sampling decision by
+    run kind) and set on the emitted ``dag_run`` span. ``getattr`` guards because
+    the values may not be populated yet at ``__init__``/clear time.
+    """
+    attributes: dict[str, str] = {}
+    dag_id = getattr(dr, "dag_id", None)
+    if dag_id is not None:
+        attributes["airflow.dag_id"] = str(dag_id)
+    run_type = getattr(dr, "run_type", None)
+    if run_type is not None:
+        attributes["airflow.run_type"] = str(run_type)
+    return attributes
+
+
 class DagRun(Base, LoggingMixin):
     """
     Invocation instance of a DAG.
@@ -383,7 +402,8 @@ class DagRun(Base, LoggingMixin):
         self.triggering_user_name = triggering_user_name
         self.scheduled_by_job_id = None
         self.context_carrier: dict[str, str] = new_dagrun_trace_carrier(
-            task_span_detail_level=self.conf.get(TASK_SPAN_DETAIL_LEVEL_KEY, None)
+            task_span_detail_level=self.conf.get(TASK_SPAN_DETAIL_LEVEL_KEY, None),
+            attributes=dagrun_trace_attributes(self),
         )
 
         if not isinstance(partition_key, str | None):
@@ -1084,7 +1104,7 @@ class DagRun(Base, LoggingMixin):
 
         with override_ids(span_context.trace_id, span_context.span_id):
             attributes: dict[str, str] = {
-                "airflow.dag_id": str(self.dag_id),
+                **dagrun_trace_attributes(self),
                 "airflow.dag_run.run_id": self.run_id,
             }
             if self.start_date:

--- a/airflow-core/src/airflow/models/taskinstance.py
+++ b/airflow-core/src/airflow/models/taskinstance.py
@@ -407,7 +407,7 @@ def clear_task_instances(
             session.merge(ti)
 
     if dag_run_state is not False and tis:
-        from airflow.models.dagrun import DagRun  # Avoid circular import
+        from airflow.models.dagrun import DagRun, dagrun_trace_attributes  # Avoid circular import
 
         run_ids_by_dag_id = defaultdict(set)
         for instance in tis:
@@ -429,7 +429,8 @@ def clear_task_instances(
             dr.clear_number += 1
             dr.queued_at = timezone.utcnow()
             dr.context_carrier = new_dagrun_trace_carrier(
-                task_span_detail_level=dr.conf.get(TASK_SPAN_DETAIL_LEVEL_KEY) if dr.conf else None
+                task_span_detail_level=dr.conf.get(TASK_SPAN_DETAIL_LEVEL_KEY) if dr.conf else None,
+                attributes=dagrun_trace_attributes(dr),
             )
 
             _recalculate_dagrun_queued_at_deadlines(dr, dr.queued_at, session)

--- a/airflow-core/tests/unit/models/test_dagrun.py
+++ b/airflow-core/tests/unit/models/test_dagrun.py
@@ -4145,9 +4145,23 @@ class TestDagRunTracing:
         assert span.name == f"dag_run.{dr.dag_id}"
         assert span.attributes["airflow.dag_id"] == dr.dag_id
         assert span.attributes["airflow.dag_run.run_id"] == dr.run_id
+        # run_type is set via the shared dagrun_trace_attributes helper
+        assert span.attributes["airflow.run_type"] == str(dr.run_type)
 
         expected_status = StatusCode.OK if final_state == DagRunState.SUCCESS else StatusCode.ERROR
         assert span.status.status_code == expected_status
+
+    def test_dagrun_trace_attributes_helper(self, dag_maker, session):
+        """The shared helper returns dag_id and run_type as airflow.* attributes."""
+        from airflow.models.dagrun import dagrun_trace_attributes
+
+        with dag_maker("test_trace_attrs_helper", session=session):
+            EmptyOperator(task_id="t1")
+        dr = dag_maker.create_dagrun(state=DagRunState.RUNNING)
+
+        attrs = dagrun_trace_attributes(dr)
+        assert attrs["airflow.dag_id"] == dr.dag_id
+        assert attrs["airflow.run_type"] == str(dr.run_type)
 
     @pytest.mark.parametrize("carrier_value", [None, {}])
     def test_emit_dagrun_span_with_none_or_empty_carrier(self, dag_maker, session, carrier_value):

--- a/shared/observability/src/airflow_shared/observability/traces/__init__.py
+++ b/shared/observability/src/airflow_shared/observability/traces/__init__.py
@@ -61,7 +61,7 @@ TASK_SPAN_DETAIL_LEVEL_KEY = "airflow/task_span_detail_level"
 DEFAULT_TASK_SPAN_DETAIL_LEVEL = 1
 
 
-def new_dagrun_trace_carrier(task_span_detail_level=None) -> dict[str, str]:
+def new_dagrun_trace_carrier(task_span_detail_level=None, attributes=None) -> dict[str, str]:
     """
     Generate a fresh W3C traceparent carrier without creating a recordable span.
 
@@ -74,6 +74,11 @@ def new_dagrun_trace_carrier(task_span_detail_level=None) -> dict[str, str]:
     Backcompat: when ``OTEL_TRACES_SAMPLER`` is unset the SDK defaults to
     ``parentbased_always_on`` whose root decision is ALWAYS_ON, so the flag is
     SAMPLED and behavior is identical to the previous hardcoded value.
+
+    ``attributes`` are forwarded to the sampler as ``should_sample`` attributes so
+    a custom sampler can differentiate the decision by run kind (e.g. by
+    ``airflow.dag_id`` / ``airflow.run_type``). The built-in samplers ignore them.
+    They are decision input only -- they are not persisted in the carrier.
     """
     gen = RandomIdGenerator()
     trace_id = gen.generate_trace_id()
@@ -85,6 +90,7 @@ def new_dagrun_trace_carrier(task_span_detail_level=None) -> dict[str, str]:
             parent_context=None,  # root decision
             trace_id=trace_id,
             name="dag_run",
+            attributes=attributes or {},
         )
         sampled = result.decision == Decision.RECORD_AND_SAMPLE
         sampler_trace_state = result.trace_state

--- a/shared/observability/tests/observability/test_traces.py
+++ b/shared/observability/tests/observability/test_traces.py
@@ -170,6 +170,44 @@ class TestNewDagrunTraceCarrierSampling:
         assert get_task_span_detail_level(span) == 2
         assert _carrier_is_sampled(carrier) is False
 
+    def test_attributes_forwarded_to_sampler(self, monkeypatch):
+        """The attributes arg is forwarded to should_sample so a custom sampler can use it."""
+        captured = {}
+
+        class _RecordingSampler:
+            def should_sample(self, parent_context, trace_id, name, attributes=None, **kwargs):
+                captured["attributes"] = attributes
+                return ALWAYS_ON.should_sample(parent_context, trace_id, name, attributes=attributes)
+
+        class _Provider:
+            sampler = _RecordingSampler()
+
+        monkeypatch.setattr(
+            "airflow_shared.observability.traces.trace.get_tracer_provider",
+            lambda: _Provider(),
+        )
+        new_dagrun_trace_carrier(attributes={"airflow.dag_id": "my_dag", "airflow.run_type": "manual"})
+        assert captured["attributes"] == {"airflow.dag_id": "my_dag", "airflow.run_type": "manual"}
+
+    def test_attributes_default_to_empty_dict(self, monkeypatch):
+        """When no attributes are passed, the sampler receives an empty dict, not None."""
+        captured = {}
+
+        class _RecordingSampler:
+            def should_sample(self, parent_context, trace_id, name, attributes=None, **kwargs):
+                captured["attributes"] = attributes
+                return ALWAYS_ON.should_sample(parent_context, trace_id, name, attributes=attributes)
+
+        class _Provider:
+            sampler = _RecordingSampler()
+
+        monkeypatch.setattr(
+            "airflow_shared.observability.traces.trace.get_tracer_provider",
+            lambda: _Provider(),
+        )
+        new_dagrun_trace_carrier()
+        assert captured["attributes"] == {}
+
 
 class TestGetTaskSpanDetailLevel:
     def _make_span_with_trace_state(self, entries: list[tuple[str, str]]) -> NonRecordingSpan:


### PR DESCRIPTION
Followup to #1589. Adds back the sampler-attributes capability that was pulled out of #1589 to keep that PR focused, now in a cleaner form.

## What

- `new_dagrun_trace_carrier` gains a generic `attributes` param, forwarded to `sampler.should_sample(..., attributes=attributes or {})`. This lets a **custom sampler** differentiate the head-sampling decision by run kind (e.g. by `airflow.dag_id` / `airflow.run_type`). The built-in samplers ignore attributes.
- New shared helper `dagrun_trace_attributes(dr)` (in `models/dagrun.py`) defines the `dag_id`/`run_type` identity attributes once.
- The helper is reused at both carrier-creation sites (`DagRun.__init__`, the clear path in `taskinstance.py`) **and** on the emitted `dag_run` span in `_emit_dagrun_span` — so "what the sampler saw" and "what's on the span" are defined in one place. The dag_run span now also carries `airflow.run_type` (previously only `dag_id`).

## Notes

- Attributes are **decision input only** at carrier creation — not persisted in the carrier (only the W3C traceparent is) and not attached to the non-recording carrier span.
- At emit time, `_emit_dagrun_span` passes its attributes into `start_span`, which the SDK forwards to `should_sample` again (the dag_run span re-samples as a root), so a custom sampler sees them there too, and any attributes it returns via `SamplingResult.attributes` get merged onto the span automatically.

## Base

Stacked on `head-sampling-honor-otel-sampler` (#1589) since it depends on the sampler-honoring change. Rebase to `main` once #1589 merges.

## Tests

- `test_traces.py`: attributes forwarded to the sampler; default to `{}` when omitted.
- `test_dagrun.py`: `dagrun_trace_attributes` helper returns dag_id/run_type; the emitted span carries `airflow.run_type`.

Tracked at ACD-177.

🤖 Generated with [Claude Code](https://claude.com/claude-code)